### PR TITLE
Brak grupowania w repo plików *.<business/config>.xml i *.<business/config>.cs.

### DIFF
--- a/src/Soneta.Sdk/Sdk/Sdk.props
+++ b/src/Soneta.Sdk/Sdk/Sdk.props
@@ -5,7 +5,6 @@
     <IsAddonProject Condition="'$(UsingMicrosoftNETSdk)' != 'true'">true</IsAddonProject>
   </PropertyGroup>
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" Condition="'$(IsAddonProject)' == 'true'"/>
-  <Import Project="common.items.props" />
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
     <IsTestProject Condition="$(IsTestProject) == '' AND $(MSBuildProjectName.Contains('Test'))">true</IsTestProject>

--- a/src/Soneta.Sdk/Sdk/Sdk.targets
+++ b/src/Soneta.Sdk/Sdk/Sdk.targets
@@ -9,7 +9,8 @@
     <OutputPath Condition="$(OutputPath) == ''">$(AggregatePath)bin\$(Configuration)</OutputPath>
     <StartArguments>/extpath=$(MSBuildProjectDirectory)\$(OutputPath)\$(SonetaTargetFramework)</StartArguments>
   </PropertyGroup>
-  
+
+  <Import Project="common.items.props" />
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" Condition=" '$(CommonTargetsPath)' == '' " />
 
   <Target Name="ResolveSonetaSchemaReferences" DependsOnTargets="ResolveAssemblyReferences">

--- a/src/Soneta.Sdk/Sdk/common.items.props
+++ b/src/Soneta.Sdk/Sdk/common.items.props
@@ -2,8 +2,7 @@
 
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <None Remove="**\*.business.xml" />
-    <None Include="**\*.business.xml" Pack="true" PackagePath="schema\%(Filename)%(Extension)" >
+    <None Update="**\*.business.xml" Pack="true" PackagePath="schema\%(Filename)%(Extension)" >
       <SubType>Designer</SubType>
     </None>
     <None Remove="**\*.config.xml" />


### PR DESCRIPTION
Kod odpowiedzialny za grupowania:

```
<Compile>
      <Compile Update="**\*.business.cs;**\*.config.cs">
      <DependentUpon>%(Filename).xml</DependentUpon>
      <SubType>Code</SubType>
      <AutoGen>True</AutoGen>
      <DesignTime>True</DesignTime>
</Compile>
```
Z moich obserwacji wynika, że winny tu jest sposób importu Soneta.Sdk. W dodatkach importujemy Soneta.Sdk w *.csproj poprzez element <Project Sdk="Soneta.Sdk"> i tam to działa.  W repo importu Soneta.Sdk dokonuje Directory.Build.props i to nie działa.

To trochę tak jak w matematyce, liczy się kolejność wykonywania działań, poniżej przedstawiam, jak mniej więcej to wygląda.

- dodatki (działa):
Directory.Build.props => *.csproj, który ustawia domyślnie element <Compile> dla plików *.cs, a następnie importuje Soneta.Sdk, który aktualizuje element <Compile> dla *.business.cs, żeby był DependentUpon *business.xml,

- enova (nie działa):
Directory.Build.props importuje Soneta.Sdk, który próbuje aktualizować element <Compile> (który chyba jeszcze nie istnieje), żeby był DependentUpon *business.xml => *.csproj, który ustawia domyślny <Compile>.

Zauważyłem, że jeśli update Compile'a zrobimy w Directory.Build.targets, to zadziała ok.