### PR TITLE
RELEASING.md

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,21 +2,21 @@
 
 ### Czynności ręczne przed wydaniem i zmierzające do wydania.
 
-1. Funkcjonalność pożądana w nowej wersji powinna być zakończona. W tym celu należy zweryfikować stan _Pull requests_.
-2. Zgłoszenia dotyczące zrealizowanej funkcjonalności powinny być zamknięte. Zweryfikować stan _Issues_.
-3. Na gałęzi `develop` w pliku [version.json] z numeru wersji **usunąć część _prerelease_** pozostawiając go w formacie `<x.y.z>`.
-   * Utworzyć commit z komunikatem stwierdzającym o zmianie wersji.
-     ```
-     git commit -m "Wersja następna: x.y.z"
-     ```
-   * Opublikować zmianę wersji.
-     ```
-     git push origin develop
-     ```
-4. Otworzyć nowy _pull request_ w celu połączenia gałęzi `develop` i `master`. W tym celu należy zalogować się do [repozytorium].
-   * Zweryfikować zmiany zakwalifikowane do wydania.
-   * Ostatnią oczekiwaną zmianą jest ta, która określa nową wersję.
-5. Zakończyć _pull request_ po uzyskaniu akceptacji. Od tego momentu wszystkie zmiany zakwalifikowane do nowej wersji znajdują się w gałęzi `master`.
+1. Zweryfikować stan synchronizacji gałęzi `develop` i `master`. W razie potrzeby wykonać odpowiednią synchronizację.
+2. Funkcjonalność pożądana w nowej wersji powinna być zakończona. W tym celu należy zweryfikować stan _Pull requests_.
+3. Zgłoszenia dotyczące zrealizowanej funkcjonalności powinny być zamknięte. Zweryfikować stan _Issues_.
+4. Na gałęzi `develop` w pliku [version.json] z numeru wersji **usunąć część _prerelease_** pozostawiając go w formacie `<x.y.z>`.
+5. Utworzyć i opublikować commit z komunikatem stwierdzającym o zmianie wersji.
+   ```
+   git commit -m "Wersja następna: x.y.z"
+   git push origin develop
+   ```
+6. Zintegrować `develop` z `master` i opublikować wydanie z `master`
+   ```
+   git checkout master
+   git merge develop
+   git push origin master
+   ```
 
 ### Część zautomatyzowana
 
@@ -25,14 +25,11 @@ Proces publikacji paczki _NuGet_ uruchomiony został automatycznie. Jest realizo
 ### Czynności ręczne po wydaniu
 
 1. Na gałęzi `develop` **przywrócić część _prerelease_** i podnieść numer wersji `<x.y.z+1>-beta.{height}` w pliku [version.json]
-   * Utworzyć commit z komunikatem stwierdzającym o zmianie wersji.
-     ```
-     git commit -m "Wersja następna: x.y.z+1-prerelease"
-     ```
-   * Opublikować zmianę przyszłej wersji.
-     ```
-     git push origin develop
-     ```
+2. Utworzyć i opublikować commit z komunikatem stwierdzającym o zmianie wersji.
+   ```
+   git commit -m "Wersja następna: x.y.z+1-prerelease"
+   git push origin develop
+   ```
 
 ##### `Koniec pracy. Gratulacje!`
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -26,7 +26,7 @@ Proces publikacji paczki _NuGet_ uruchomiony został automatycznie. Jest realizo
 
 1. Po weryfikacji wersji do wydania utworzyć i opublikować tag w punkcie w jakim znajduje się gałąź `master`
    ```
-   git tag x.y.z origin/master
+   git tag -a x.y.z origin/master
    git push origin --tags
    ```
 2. Na gałęzi `develop` **przywrócić część _prerelease_** i podnieść numer wersji `<x.y.z+1>-beta.{height}` w pliku [version.json]

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -26,7 +26,7 @@ Proces publikacji paczki _NuGet_ uruchomiony został automatycznie. Jest realizo
 
 1. Po weryfikacji wersji do wydania utworzyć i opublikować tag w punkcie w jakim znajduje się gałąź `master`
    ```
-   git tag -a x.y.z origin/master
+   git tag -a vx.y.z origin/master
    git push origin --tags
    ```
 2. Na gałęzi `develop` **przywrócić część _prerelease_** i podnieść numer wersji `<x.y.z+1>-beta.{height}` w pliku [version.json]

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -24,8 +24,13 @@ Proces publikacji paczki _NuGet_ uruchomiony został automatycznie. Jest realizo
 
 ### Czynności ręczne po wydaniu
 
-1. Na gałęzi `develop` **przywrócić część _prerelease_** i podnieść numer wersji `<x.y.z+1>-beta.{height}` w pliku [version.json]
-2. Utworzyć i opublikować commit z komunikatem stwierdzającym o zmianie wersji.
+1. Po weryfikacji wersji do wydania utworzyć i opublikować tag w punkcie w jakim znajduje się gałąź `master`
+   ```
+   git tag x.y.z origin/master
+   git push origin --tags
+   ```
+2. Na gałęzi `develop` **przywrócić część _prerelease_** i podnieść numer wersji `<x.y.z+1>-beta.{height}` w pliku [version.json]
+3. Utworzyć i opublikować commit z komunikatem stwierdzającym o zmianie wersji.
    ```
    git commit -m "Wersja następna: x.y.z+1-prerelease"
    git push origin develop


### PR DESCRIPTION
W poprzedniej wersji pojechałem trochę za daleko z tymi pull requestami. 
To nie sprzyja utrzymaniu doskonałej synchronizacji master i develop, bo pull request kończy się często merge-commit-em. Choć szkoda, że przez to tracimy okazję zerknięcia na skumulowane zmiany w wersji.