### PR TITLE
Informacja o posiadaniu starej wersji SDK

### DIFF
--- a/src/Soneta.Sdk/Sdk/Sdk.targets
+++ b/src/Soneta.Sdk/Sdk/Sdk.targets
@@ -43,8 +43,8 @@
       <Using Namespace="System.Text.RegularExpressions" />
       <Code Type="Method" Language="cs">
         <![CDATA[
-        private const string GlobalJsonSdkVersionPattern = @"(?<=""Soneta.Sdk""\s*:\s*"")[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?(?=.*?"")";
-        private const string NugetApiLatestVersionPattern = @"(?<="")[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?(?=.*?""\s*])";
+        private const string GlobalJsonSdkVersionPattern = @"(?<=""Soneta.Sdk""\s*:\s*"")([0-9]+\.?){3,}(?=.*?"")";
+        private const string NugetApiLatestVersionPattern = @"(?<="")([0-9]+\.?){3,}(?=.*?""\s*])";
         
         public override bool Execute()
         {

--- a/src/Soneta.Sdk/Sdk/Sdk.targets
+++ b/src/Soneta.Sdk/Sdk/Sdk.targets
@@ -10,7 +10,8 @@
   <PropertyGroup>
     <GlobalJsonFilePath>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), global.json))\global.json</GlobalJsonFilePath>
     <SonetaSdkLatestVersionFilePath>$(NuGetPackageRoot)soneta.sdk\latest_version.txt</SonetaSdkLatestVersionFilePath>
-    <PS>powershell.exe -WindowStyle Hidden -Sta -NoLogo -NonInteractive -NoProfile -Command</PS>
+    <SonetaSdkNugetApiUrl>https://api.nuget.org/v3-flatcontainer/soneta.sdk/index.json</SonetaSdkNugetApiUrl>
+    <SonetaSdkUpdateInterval Condition="'$(SonetaSdkUpdateInterval)' == ''">1</SonetaSdkUpdateInterval>
   </PropertyGroup>
 
   <Import Project="common.items.props" />
@@ -24,21 +25,107 @@
     <RunArguments>$(StartArguments)</RunArguments>
   </PropertyGroup>
 
-  <Target Name="WriteSonetaSdkLatestVersion" BeforeTargets="Restore">
-    <Exec Command="$(PS) (Invoke-RestMethod -Uri 'https://api.nuget.org/v3-flatcontainer/soneta.sdk/index.json').versions[-1]" ConsoleToMsBuild='true' EchoOff='true'>
-      <Output TaskParameter="ConsoleOutput" PropertyName="SonetaSdkLatestVersion" />
-    </Exec>
-    <WriteLinesToFile File="$(SonetaSdkLatestVersionFilePath)" Overwrite="true" Lines="$(SonetaSdkLatestVersion)" />
-  </Target>
+  <UsingTask TaskName="CheckForSdkUpdates" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildBinPath)\Microsoft.Build.Tasks.Core.dll">
+    <ParameterGroup>
+      <GlobalJsonFilePath ParameterType="System.String" Required="true" />
+      <LatestVersionFilePath ParameterType="System.String" Required="true" />
+      <NugetApiUrl ParameterType="System.String" Required="true" />
+      <SdkName ParameterType="System.String" Required="true" />
+      <UpdateInterval ParameterType="System.Int32" Required="true" />
+      <IsUpdateAvailable ParameterType="System.Boolean" Output="true" />
+      <CurrentVersion ParameterType="System.String" Output="true" />
+      <LatestVersion ParameterType="System.String" Output="true" />
+    </ParameterGroup>
 
-  <Target Name="CheckSonetaSdkCurrentVersion" BeforeTargets="Build" Condition="Exists($(GlobalJsonFilePath))">
-    <Exec Command="$(PS) &quot;(Get-Content '$(GlobalJsonFilePath)' | ConvertFrom-Json).'msbuild-sdks'.'Soneta.Sdk'&quot;" ConsoleToMsBuild='true' EchoOff='true'>
-      <Output TaskParameter="ConsoleOutput" PropertyName="SonetaSdkCurrentVersion" />
-    </Exec>
-    <ReadLinesFromFile File="$(SonetaSdkLatestVersionFilePath)">
-      <Output TaskParameter="Lines" PropertyName="SonetaSdkLatestVersion"/>
-    </ReadLinesFromFile>
-    <Warning Text="Aktualnie używana wersja 'Soneta.Sdk' to: '$(SonetaSdkCurrentVersion)', istnieje nowsza wersja: '$(SonetaSdkLatestVersion)'. Aby ją ustawić, w pliku 'global.json' należy zamienić aktualny numer wesji 'Soneta.Sdk' na nowy." Condition="$(SonetaSdkLatestVersion) > $(SonetaSdkCurrentVersion)" />
+    <Task>
+      <Using Namespace="System.Linq" />
+      <Using Namespace="System.Net.Http" />
+      <Using Namespace="System.Text.RegularExpressions" />
+      <Code Type="Method" Language="cs">
+        <![CDATA[
+        public override bool Execute()
+        {
+            CurrentVersion = GetCurrentVersion();
+            LatestVersion = GetLatestVersion();
+            IsUpdateAvailable = CheckIfUpdateAvailable(CurrentVersion, LatestVersion);
+
+            return true;
+        }
+
+        private string GetCurrentVersion()
+        {
+            if (File.Exists(GlobalJsonFilePath))
+            {
+                var json = File.ReadAllText(GlobalJsonFilePath);
+                var pattern = $@"(?<=""{SdkName}""\s*:\s*"")[0-9]+\.[0-9]+\.[0-9]+.*?(?="")";
+                return GetMatchingValue(json, pattern);
+            }
+
+            return null;
+        }
+
+        private string GetLatestVersion()
+        {
+            var lastWriteTime = File.GetLastWriteTime(LatestVersionFilePath);
+            var updateTime = lastWriteTime.AddMinutes(UpdateInterval);
+
+            if (updateTime < DateTime.Now)
+            {
+                var latestVersion = GetLastVersionFromApi();
+
+                using (var sw = File.CreateText(LatestVersionFilePath))
+                    sw.WriteLine(latestVersion);
+
+                return latestVersion;
+            }
+            else
+            {
+                return File.ReadAllText(LatestVersionFilePath).Trim();
+            }
+        }
+
+        private string GetLastVersionFromApi()
+        {
+            using (var httpClient = new HttpClient())
+            {
+                var json = httpClient.GetStringAsync(NugetApiUrl).Result;
+                var pattern = $@"(?<="")[0-9]+\.[0-9]+\.[0-9]+.*?(?=""\s*])";
+                return GetMatchingValue(json, pattern);
+            }
+        }
+
+        private string GetMatchingValue(string json, string pattern)
+        {
+            var match = Regex.Match(json, pattern);
+            return match.Value;
+        }
+
+        private static bool CheckIfUpdateAvailable(string current, string latest)
+        {
+            if (string.IsNullOrEmpty(current) || string.IsNullOrEmpty(latest))
+                return false;
+
+            var currentVersion = new Version(current);
+            var latestVersion = new Version(latest);
+            return currentVersion.CompareTo(latestVersion) is -1;
+        }
+        ]]>
+      </Code>
+    </Task>
+  </UsingTask>
+
+  <Target Name="SonetaSdkCheckForUpdates" AfterTargets="Build" Condition="Exists($(GlobalJsonFilePath))">
+    <CheckForSdkUpdates
+      GlobalJsonFilePath="$(GlobalJsonFilePath)"
+      LatestVersionFilePath="$(SonetaSdkLatestVersionFilePath)"
+      NugetApiUrl="$(SonetaSdkNugetApiUrl)"
+      SdkName="Soneta.Sdk"
+      UpdateInterval="$(SonetaSdkUpdateInterval)">
+      <Output TaskParameter="IsUpdateAvailable" PropertyName="IsSonetaSdkUpdateAvailable" />
+      <Output TaskParameter="CurrentVersion" PropertyName="SonetaSdkCurrentVersion" />
+      <Output TaskParameter="LatestVersion" PropertyName="SonetaSdkLatestVersion" />
+    </CheckForSdkUpdates>
+    <Warning Condition="$(IsSonetaSdkUpdateAvailable)" Text="Aktualnie używana wersja 'Soneta.Sdk' to: '$(SonetaSdkCurrentVersion)', istnieje nowsza wersja: '$(SonetaSdkLatestVersion)'. Aby ją ustawić, w pliku 'global.json' należy zamienić aktualny numer wesji 'Soneta.Sdk' na nowy." />
   </Target>
 
   <Target Name="ResolveSonetaSchemaReferences" DependsOnTargets="ResolveAssemblyReferences">

--- a/src/Soneta.Sdk/Sdk/Sdk.targets
+++ b/src/Soneta.Sdk/Sdk/Sdk.targets
@@ -11,7 +11,8 @@
     <GlobalJsonFilePath>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), global.json))\global.json</GlobalJsonFilePath>
     <SonetaSdkLatestVersionFilePath>$(NuGetPackageRoot)soneta.sdk\latest_version.txt</SonetaSdkLatestVersionFilePath>
     <SonetaSdkNugetApiUrl>https://api.nuget.org/v3-flatcontainer/soneta.sdk/index.json</SonetaSdkNugetApiUrl>
-    <SonetaSdkUpdateInterval Condition="'$(SonetaSdkUpdateInterval)' == ''">1</SonetaSdkUpdateInterval>
+    <SonetaSdkUpdateIntervalValue Condition="'$(SonetaSdkUpdateIntervalValue)' == ''">1</SonetaSdkUpdateIntervalValue>
+    <SonetaSdkUpdateIntervalTime Condition="'$(SonetaSdkUpdateIntervalTime)' == ''">Minutes</SonetaSdkUpdateIntervalTime>
   </PropertyGroup>
 
   <Import Project="common.items.props" />
@@ -30,8 +31,8 @@
       <GlobalJsonFilePath ParameterType="System.String" Required="true" />
       <LatestVersionFilePath ParameterType="System.String" Required="true" />
       <NugetApiUrl ParameterType="System.String" Required="true" />
-      <SdkName ParameterType="System.String" Required="true" />
       <UpdateInterval ParameterType="System.Int32" Required="true" />
+      <UpdateIntervalUnit ParameterType="System.String" Required="true" />
       <IsUpdateAvailable ParameterType="System.Boolean" Output="true" />
       <CurrentVersion ParameterType="System.String" Output="true" />
       <LatestVersion ParameterType="System.String" Output="true" />
@@ -43,9 +44,21 @@
       <Using Namespace="System.Text.RegularExpressions" />
       <Code Type="Method" Language="cs">
         <![CDATA[
+        public enum TimeUnit
+        {
+            None,
+            Seconds,
+            Minutes,
+            Hours,
+            Days,
+            Weeks,
+            Months,
+            Years
+        }
+
         private const string GlobalJsonSdkVersionPattern = @"(?<=""Soneta.Sdk""\s*:\s*"")([0-9]+\.?){3,}(?=.*?"")";
         private const string NugetApiLatestVersionPattern = @"(?<="")([0-9]+\.?){3,}(?=.*?""\s*])";
-        
+
         public override bool Execute()
         {
             CurrentVersion = GetCurrentVersion();
@@ -66,27 +79,52 @@
             return null;
         }
 
+        private string GetMatchingValue(string json, string pattern)
+        {
+            var match = Regex.Match(json, pattern);
+            return match.Value;
+        }
+
         private string GetLatestVersion()
         {
+            return CalculateUpdateCheckTime() < DateTime.Now ? 
+                GetRemoteVersion() : GetLocalVersion();
+        }
+
+        private DateTime CalculateUpdateCheckTime() 
+        {
             var lastWriteTime = File.GetLastWriteTime(LatestVersionFilePath);
-            var updateTime = lastWriteTime.AddMinutes(UpdateInterval);
+            Enum.TryParse(UpdateIntervalUnit, out TimeUnit unit);
 
-            if (updateTime < DateTime.Now)
+            switch (unit)
             {
-                var latestVersion = GetLastVersionFromApi();
-
-                using (var sw = File.CreateText(LatestVersionFilePath))
-                    sw.WriteLine(latestVersion);
-
-                return latestVersion;
-            }
-            else
-            {
-                return File.ReadAllText(LatestVersionFilePath).Trim();
+                case TimeUnit.Seconds:
+                    return lastWriteTime.AddSeconds(UpdateInterval);
+                case TimeUnit.Minutes:
+                    return lastWriteTime.AddMinutes(UpdateInterval);
+                case TimeUnit.Hours:
+                    return lastWriteTime.AddHours(UpdateInterval);
+                case TimeUnit.Days:
+                    return lastWriteTime.AddDays(UpdateInterval);
+                case TimeUnit.Weeks:
+                    return lastWriteTime.AddDays(UpdateInterval * 7);
+                case TimeUnit.Months:
+                    return lastWriteTime.AddMonths(UpdateInterval);
+                case TimeUnit.Years:
+                    return lastWriteTime.AddYears(UpdateInterval);
+                default:
+                    return DateTime.MaxValue;
             }
         }
 
-        private string GetLastVersionFromApi()
+        private string GetRemoteVersion()
+        {
+            var latestVersion = GetLatestVersionFromApi();
+            StoreLatestVersion(latestVersion);
+            return latestVersion;
+        }
+
+        private string GetLatestVersionFromApi()
         {
             using (var httpClient = new HttpClient())
             {
@@ -95,10 +133,15 @@
             }
         }
 
-        private string GetMatchingValue(string json, string pattern)
+        private void StoreLatestVersion(string version) 
         {
-            var match = Regex.Match(json, pattern);
-            return match.Value;
+            using (var sw = File.CreateText(LatestVersionFilePath))
+                sw.WriteLine(version);
+        }
+
+        private string GetLocalVersion() 
+        {
+            return File.ReadAllText(LatestVersionFilePath).Trim();
         }
 
         private static bool CheckIfUpdateAvailable(string current, string latest)
@@ -115,13 +158,13 @@
     </Task>
   </UsingTask>
 
-  <Target Name="SonetaSdkCheckForUpdates" AfterTargets="Build" Condition="Exists($(GlobalJsonFilePath))">
+  <Target Name="SonetaSdkCheckForUpdates" AfterTargets="Build" Condition="Exists($(GlobalJsonFilePath)) AND $(SonetaSdkUpdateIntervalTime) != 'None'">
     <CheckForSdkUpdates
       GlobalJsonFilePath="$(GlobalJsonFilePath)"
       LatestVersionFilePath="$(SonetaSdkLatestVersionFilePath)"
       NugetApiUrl="$(SonetaSdkNugetApiUrl)"
-      SdkName="Soneta.Sdk"
-      UpdateInterval="$(SonetaSdkUpdateInterval)">
+      UpdateIntervalUnit="$(SonetaSdkUpdateIntervalTime)"
+      UpdateInterval="$(SonetaSdkUpdateIntervalValue)">
       <Output TaskParameter="IsUpdateAvailable" PropertyName="IsSonetaSdkUpdateAvailable" />
       <Output TaskParameter="CurrentVersion" PropertyName="SonetaSdkCurrentVersion" />
       <Output TaskParameter="LatestVersion" PropertyName="SonetaSdkLatestVersion" />

--- a/src/Soneta.Sdk/Sdk/Sdk.targets
+++ b/src/Soneta.Sdk/Sdk/Sdk.targets
@@ -12,7 +12,7 @@
     <SonetaSdkLatestVersionFilePath>$(NuGetPackageRoot)soneta.sdk\latest_version.txt</SonetaSdkLatestVersionFilePath>
     <SonetaSdkNugetApiUrl>https://api.nuget.org/v3-flatcontainer/soneta.sdk/index.json</SonetaSdkNugetApiUrl>
     <SonetaSdkUpdateIntervalValue Condition="'$(SonetaSdkUpdateIntervalValue)' == ''">1</SonetaSdkUpdateIntervalValue>
-    <SonetaSdkUpdateIntervalTime Condition="'$(SonetaSdkUpdateIntervalTime)' == ''">Minutes</SonetaSdkUpdateIntervalTime>
+    <SonetaSdkUpdateIntervalTime Condition="'$(SonetaSdkUpdateIntervalTime)' == ''">None</SonetaSdkUpdateIntervalTime>
   </PropertyGroup>
 
   <Import Project="common.items.props" />

--- a/src/Soneta.Sdk/Sdk/Sdk.targets
+++ b/src/Soneta.Sdk/Sdk/Sdk.targets
@@ -7,6 +7,12 @@
     <BaseOutputPath>$(AggregatePath)bin\</BaseOutputPath>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <GlobalJsonFilePath>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), global.json))\global.json</GlobalJsonFilePath>
+    <SonetaSdkLatestVersionFilePath>$(NuGetPackageRoot)soneta.sdk\latest_version.txt</SonetaSdkLatestVersionFilePath>
+    <PS>powershell.exe -WindowStyle Hidden -Sta -NoLogo -NonInteractive -NoProfile -Command</PS>
+  </PropertyGroup>
+
   <Import Project="common.items.props" />
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" Condition=" '$(CommonTargetsPath)' == '' " />
 
@@ -17,6 +23,23 @@
     <RunCommand>$(StartProgram)</RunCommand>
     <RunArguments>$(StartArguments)</RunArguments>
   </PropertyGroup>
+
+  <Target Name="WriteSonetaSdkLatestVersion" BeforeTargets="Restore">
+    <Exec Command="$(PS) (Invoke-RestMethod -Uri 'https://api.nuget.org/v3-flatcontainer/soneta.sdk/index.json').versions[-1]" ConsoleToMsBuild='true' EchoOff='true'>
+      <Output TaskParameter="ConsoleOutput" PropertyName="SonetaSdkLatestVersion" />
+    </Exec>
+    <WriteLinesToFile File="$(SonetaSdkLatestVersionFilePath)" Overwrite="true" Lines="$(SonetaSdkLatestVersion)" />
+  </Target>
+
+  <Target Name="CheckSonetaSdkCurrentVersion" BeforeTargets="Build" Condition="Exists($(GlobalJsonFilePath))">
+    <Exec Command="$(PS) &quot;(Get-Content '$(GlobalJsonFilePath)' | ConvertFrom-Json).'msbuild-sdks'.'Soneta.Sdk'&quot;" ConsoleToMsBuild='true' EchoOff='true'>
+      <Output TaskParameter="ConsoleOutput" PropertyName="SonetaSdkCurrentVersion" />
+    </Exec>
+    <ReadLinesFromFile File="$(SonetaSdkLatestVersionFilePath)">
+      <Output TaskParameter="Lines" PropertyName="SonetaSdkLatestVersion"/>
+    </ReadLinesFromFile>
+    <Warning Text="Aktualnie używana wersja 'Soneta.Sdk' to: '$(SonetaSdkCurrentVersion)', istnieje nowsza wersja: '$(SonetaSdkLatestVersion)'. Aby ją ustawić, w pliku 'global.json' należy zamienić aktualny numer wesji 'Soneta.Sdk' na nowy." Condition="$(SonetaSdkLatestVersion) > $(SonetaSdkCurrentVersion)" />
+  </Target>
 
   <Target Name="ResolveSonetaSchemaReferences" DependsOnTargets="ResolveAssemblyReferences">
     <ItemGroup>
@@ -38,7 +61,7 @@
     <Error Text="Soneta.Generator.exe is missing." Condition=" '@(SonetaGeneratorExe)' == '' " />
 
     <PropertyGroup>
-        <MetadataToRemove>Pack;PackagePath;SubType</MetadataToRemove>
+      <MetadataToRemove>Pack;PackagePath;SubType</MetadataToRemove>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Soneta.Sdk/Sdk/Sdk.targets
+++ b/src/Soneta.Sdk/Sdk/Sdk.targets
@@ -43,6 +43,9 @@
       <Using Namespace="System.Text.RegularExpressions" />
       <Code Type="Method" Language="cs">
         <![CDATA[
+        private const string GlobalJsonSdkVersionPattern = @"(?<=""Soneta.Sdk""\s*:\s*"")[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?(?=.*?"")";
+        private const string NugetApiLatestVersionPattern = @"(?<="")[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?(?=.*?""\s*])";
+        
         public override bool Execute()
         {
             CurrentVersion = GetCurrentVersion();
@@ -57,8 +60,7 @@
             if (File.Exists(GlobalJsonFilePath))
             {
                 var json = File.ReadAllText(GlobalJsonFilePath);
-                var pattern = $@"(?<=""{SdkName}""\s*:\s*"")[0-9]+\.[0-9]+\.[0-9]+.*?(?="")";
-                return GetMatchingValue(json, pattern);
+                return GetMatchingValue(json, GlobalJsonSdkVersionPattern);
             }
 
             return null;
@@ -89,8 +91,7 @@
             using (var httpClient = new HttpClient())
             {
                 var json = httpClient.GetStringAsync(NugetApiUrl).Result;
-                var pattern = $@"(?<="")[0-9]+\.[0-9]+\.[0-9]+.*?(?=""\s*])";
-                return GetMatchingValue(json, pattern);
+                return GetMatchingValue(json, NugetApiLatestVersionPattern);
             }
         }
 


### PR DESCRIPTION
Issue: #19
Analiza wykonalności - prototyp I.

W poszukiwaniu bardziej optymalnego rozwiązania, znalazłem PR do msbuild'a, który dodaje logikę, która sprawdza numer wersji SDK w pliku global.json, tzw. NuGet-based SDK resolver. Niestety brakuje mi wiedzy, żeby stwierdzić, czy jesteśmy w stanie jakoś wykorzystać to co oni napisali w naszym rozwiązaniu. Jeśli ktoś kompetentniejszy ode mnie chciałby się temu przyjrzeć, poniżej zamieszczam link:

https://github.com/microsoft/msbuild/pull/2850/files