### PR TITLE
Task #58145: Unifikacja działania Soneta.Generator - obsługa import w…

### DIFF
--- a/src/Soneta.Sdk/Sdk/Sdk.targets
+++ b/src/Soneta.Sdk/Sdk/Sdk.targets
@@ -172,18 +172,18 @@
     <Warning Condition="$(IsSonetaSdkUpdateAvailable)" Text="Aktualnie używana wersja 'Soneta.Sdk' to: '$(SonetaSdkCurrentVersion)', istnieje nowsza wersja: '$(SonetaSdkLatestVersion)'. Aby ją ustawić, w pliku 'global.json' należy zamienić aktualny numer wesji 'Soneta.Sdk' na nowy." />
   </Target>
 
-  <Target Name="ResolveSonetaSchemaReferences" DependsOnTargets="ResolveAssemblyReferences">
+  <Target Name="ResolveSonetaSchemaReferences" DependsOnTargets="ResolvePackageAssets">
     <ItemGroup>
-      <SonetaSchemaReference Include="$([System.IO.Path]::GetDirectoryName( '%(Reference.HintPath)' ))\..\..\schema\*.business.xml"
-        Condition="$( [System.String]::new( '%( Reference.HintPath )' ).Trim().Length ) &gt; 0" />
+      <SonetaSchemaReference Include="$([System.IO.Path]::GetDirectoryName( '%(ResolvedCompileFileDefinitions.HintPath)' ))\..\..\schema\*.business.xml"
+        Condition="$( [System.String]::new( '%( ResolvedCompileFileDefinitions.HintPath )' ).Trim().Length ) &gt; 0" />
     </ItemGroup>
     <Message Text="SonetaSchemaReference: %(SonetaSchemaReference.Identity)" />
   </Target>
 
-  <Target Name="ResolveSonetaGeneratorExe" DependsOnTargets="ResolveAssemblyReferences">
+  <Target Name="ResolveSonetaGeneratorExe" DependsOnTargets="ResolvePackageAssets">
     <ItemGroup>
-      <SonetaGeneratorExe Include="%(Reference.HintPath)"
-        Condition="$( [System.String]::new( '%( Reference.HintPath )' ).Contains( 'Soneta.Generator.exe' ) )" />
+      <SonetaGeneratorExe Include="%(ResolvedCompileFileDefinitions.HintPath)"
+        Condition="$( [System.String]::new( '%( ResolvedCompileFileDefinitions.HintPath )' ).Contains( 'Soneta.Generator.exe' ) )" />
     </ItemGroup>
     <Message Text="SonetaGeneratorExe: @(SonetaGeneratorExe)" />
   </Target>
@@ -196,31 +196,37 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <BusinessXmls Include="@(None)" Condition="$([System.String]::new('%(Filename)%(Extension)').EndsWith('business.xml', StringComparison.InvariantCultureIgnoreCase ))"/>
-      <ConfigXmls Include="@(EmbeddedResource)" Condition="$([System.String]::new('%(Filename)%(Extension)').EndsWith('config.xml', StringComparison.InvariantCultureIgnoreCase ))"/>
-      <WorkingXmls Include="@(BusinessXmls)" RemoveMetadata="$(MetadataToRemove)"/>
-      <WorkingXmls Include="@(ConfigXmls)" RemoveMetadata="$(MetadataToRemove)"/>
+      <WorkingXmls 
+        Include="@(None)" 
+        Condition="$([System.String]::new('%(Filename)%(Extension)').EndsWith('business.xml', StringComparison.InvariantCultureIgnoreCase ))"
+        RemoveMetadata="$(MetadataToRemove)" />
+      <WorkingXmls 
+        Include="@(EmbeddedResource)" 
+        Condition="$([System.String]::new('%(Filename)%(Extension)').EndsWith('config.xml', StringComparison.InvariantCultureIgnoreCase ))"
+        RemoveMetadata="$(MetadataToRemove)" />
     </ItemGroup>
   </Target>
 
-  <Target Name="ExecuteSonetaGenerator" BeforeTargets="CoreCompile" DependsOnTargets="PrepareSonetaGeneratorAssets"
-          Condition=" ( '$(RunSonetaGenerator)' == '' OR '$(RunSonetaGenerator)' != 'false' ) AND $( [System.IO.Directory]::GetFiles( '$(ProjectDir)' , '*.business.xml', SearchOption.AllDirectories ).Length ) &gt; 0 "
-          Inputs="%(WorkingXmls.Identity)" Outputs="@(WorkingXmls->'%(RelativeDir)%(Filename).cs')">
+  <Target Name="ExecuteSonetaGenerator" BeforeTargets="BeforeCompile;CoreCompile" DependsOnTargets="PrepareSonetaGeneratorAssets"
+          Condition="( '$(RunSonetaGenerator)' == '' OR '$(RunSonetaGenerator)' != 'false' ) 
+            AND (
+              $( [System.IO.Directory]::GetFiles( '$(ProjectDir)' , '*.business.xml', SearchOption.AllDirectories ).Length ) &gt; 0
+                OR 
+              $( [System.IO.Directory]::GetFiles( '$(ProjectDir)' , '*.config.xml', SearchOption.AllDirectories ).Length ) &gt; 0
+            )"
+          Inputs="@(WorkingXmls)" 
+          Outputs="%(RelativeDir)%(Filename).cs">
 
+    <Exec Command="&quot;@(SonetaGeneratorExe)&quot; -s @(SonetaSchemaReference->'&quot;%(FullPath)&quot;',' ') &quot;%(WorkingXmls.FullPath)&quot;" />
+    
     <ItemGroup>
-      <!-- Replace-hack służy do wyeliminowania pliku X.business.xml w chwili przetwarzania skojarzonego z nim X.config.xml -->
-      <SameAssemblyBusinessXmls Include="@(BusinessXmls)" Exclude="@(WorkingXmls->'%(Identity)'->Replace('.config.xml','.business.xml')->Replace('.Config.xml','.Business.xml'))"/>
-    </ItemGroup>
-
-    <Exec Condition="'$(SavedFile)' != '' AND '%(WorkingXmls.FullPath)' == '$(SavedFile)'"
-          Command="&quot;@(SonetaGeneratorExe)&quot; &quot;$(SavedFile)&quot; FILE" />
-    <Exec Condition="'@(SonetaSchemaReference->Count())' &gt; 0 AND '@(WorkingXmls->Count())' &gt; 0"
-          Command="&quot;@(SonetaGeneratorExe)&quot; -s &quot;@(SonetaSchemaReference,'&quot; &quot;')&quot; @(SameAssemblyBusinessXmls,' ') &quot;%(WorkingXmls.FullPath)&quot;" />
-
-    <ItemGroup>
-      <GeneratedCs Include="@(WorkingXmls->'%(RelativeDir)%(Filename).cs')"/>
-      <Compile Remove="@(GeneratedCs)" />
-      <Compile Include="@(GeneratedCs)"/>
+      <Compile Remove="%(WorkingXmls.RelativeDir)%(WorkingXmls.Filename).cs" />
+      <Compile Include="%(WorkingXmls.RelativeDir)%(WorkingXmls.Filename).cs">
+        <DependentUpon>%(WorkingXmls.Filename).xml</DependentUpon>
+        <SubType>Code</SubType>
+        <AutoGen>True</AutoGen>
+        <DesignTime>True</DesignTime>
+      </Compile>
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
… trybie --schema - Soneta.MSBuild.SDK

Zmiany dążą do poprawnego generowania plików business.cs i config.cs w głównym repozytorium soneta.
Komplet stanowią odpowiednie PR w ADO firmy Soneta.

Konsekwencje dla dodatków to potrzeba referowania w business.xml do innych plików business.xml w repozytorium, od których zależy nasz moduł poprzez element import - można stosować <import>..</import> co załaduje wszystkie zależne business.xml z wyższego katalogi i wszystkich podrzędnych.