### PR TITLE
Poprawka błędu #49

### DIFF
--- a/src/Soneta.Sdk/Sdk/Sdk.targets
+++ b/src/Soneta.Sdk/Sdk/Sdk.targets
@@ -21,7 +21,7 @@
   <PropertyGroup Condition="'$(IsTestProject)' != 'true' AND $(StartProgram) == '' AND Exists($(SonetaAddonStartProgram))">
     <StartAction>Program</StartAction>
     <StartProgram>$(SonetaAddonStartProgram)</StartProgram>
-    <StartArguments>/extpath="$(MSBuildProjectDirectory)\$(OutputPath)"</StartArguments>
+    <StartArguments>/extpath="$(MSBuildProjectDirectory)\$(OutputPath)\"</StartArguments>
     <RunCommand>$(StartProgram)</RunCommand>
     <RunArguments>$(StartArguments)</RunArguments>
   </PropertyGroup>


### PR DESCRIPTION
Naprawia błędną ścieżkę parametru /extpath w argumencie uruchomienia programu Enova.
Fix dodaje backslash na końcu ścieżki, dzięki czemu nie generuje się dodatkowy cudzysłów na końcu ścieżki.