### PR TITLE
Zduplikowane referencje do schem

### DIFF
--- a/src/Soneta.Sdk/Sdk/Sdk.props
+++ b/src/Soneta.Sdk/Sdk/Sdk.props
@@ -16,6 +16,7 @@
     <SonetaNSubstitutePackageVersion>4.2.1</SonetaNSubstitutePackageVersion>
     <SonetaFluentAssertionsPackageVersion>5.9.0</SonetaFluentAssertionsPackageVersion>
     <UsingSonetaSdk>true</UsingSonetaSdk>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <PropertyGroup Condition="'$(IsAddonProject)' == 'true' AND '$(IsTestProject)' != 'true' AND $(SonetaAddonStartProgram) == ''">
     <SonetaDefaultInstallDirectory>$(MSBuildProgramFiles32)\Soneta</SonetaDefaultInstallDirectory>

--- a/src/Soneta.Sdk/Sdk/Sdk.targets
+++ b/src/Soneta.Sdk/Sdk/Sdk.targets
@@ -174,8 +174,9 @@
 
   <Target Name="ResolveSonetaSchemaReferences" DependsOnTargets="ResolvePackageAssets">
     <ItemGroup>
-      <SonetaSchemaReference Include="$([System.IO.Path]::GetDirectoryName( '%(ResolvedCompileFileDefinitions.HintPath)' ))\..\..\schema\*.business.xml"
+      <SonetaSchemaReferencePossibleDuplicates Include="$([System.IO.Path]::GetDirectoryName( '%(ResolvedCompileFileDefinitions.HintPath)' ))\..\..\schema\*.business.xml"
         Condition="$( [System.String]::new( '%( ResolvedCompileFileDefinitions.HintPath )' ).Trim().Length ) &gt; 0" />
+      <SonetaSchemaReference Include="@(SonetaSchemaReferencePossibleDuplicates->Distinct())" />
     </ItemGroup>
     <Message Text="SonetaSchemaReference: %(SonetaSchemaReference.Identity)" />
   </Target>


### PR DESCRIPTION
spowodowanych obecnością biliotek dll w ilości większej niż jedna
w folderze lib\[target_framework] w biznesowej paczce nuget Soneta.

Dodatkowo CopyLocalLockFileAssemblies: true (build jak publish)
