### PR TITLE
Pliki *.repx traktowane jako EmbeddedResources

### DIFF
--- a/src/Soneta.Sdk/Sdk/common.items.props
+++ b/src/Soneta.Sdk/Sdk/common.items.props
@@ -43,10 +43,10 @@
     <EmbeddedResource Include="**\Repx\*.png" />
     <None Remove="**\Repx\*.bmp" />
     <EmbeddedResource Include="**\Repx\*.bmp" />
+    <None Remove="**\*.repx" />
+    <EmbeddedResource Include="**\*.repx" />
 
-    <Compile Update="**\*.repx.cs">
-      <SubType>Component</SubType>
-    </Compile>
+    <Compile Update="**\*.repx.cs"/>
     <EmbeddedResource Include="**\*.repx.cs" />
 
     <None Remove="**\*.role.xml" />

--- a/src/Soneta.Sdk/version.json
+++ b/src/Soneta.Sdk/version.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
 
-  "version": "1.1.4",
+  "version": "1.1.5-alfa",
 
   "assemblyVersion": {
     "precision": "revision"


### PR DESCRIPTION
Zmiana potrzebna ze względu na konwersję raportów REPX z formatu w kodzie repx.cs, na format XML + snippet-y