### PR TITLE
Dostosowanie extPath do nowego sposobu z użyciem --. Usunięcie ""

### DIFF
--- a/src/Soneta.Sdk/Sdk/Sdk.targets
+++ b/src/Soneta.Sdk/Sdk/Sdk.targets
@@ -21,7 +21,7 @@
   <PropertyGroup Condition="'$(IsTestProject)' != 'true' AND $(StartProgram) == '' AND Exists($(SonetaAddonStartProgram))">
     <StartAction>Program</StartAction>
     <StartProgram>$(SonetaAddonStartProgram)</StartProgram>
-    <StartArguments>/extpath="$(MSBuildProjectDirectory)\$(OutputPath)\"</StartArguments>
+    <StartArguments>--extpath=$(MSBuildProjectDirectory)\$(OutputPath)\</StartArguments>
     <RunCommand>$(StartProgram)</RunCommand>
     <RunArguments>$(StartArguments)</RunArguments>
   </PropertyGroup>


### PR DESCRIPTION
exptPath zmieniony z /extPath na --extPath.

Usunięcie cydzysłowiu. Od tej pory dodatek musi być w lokalizacji gdzie path nie ma spacji.