### PR TITLE
docs: CHANGELOG oraz przebudowa README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ a nie dacie commita podnoszącego numer wersji — te potrafiły różnić się 
 > pomiędzy kolejnymi commitami wydaniowymi. Szczegóły metody i znane niepewności opisano
 > w sekcji [Uwagi do rekonstrukcji](#uwagi-do-rekonstrukcji) na końcu pliku.
 
-## [Nieopublikowane]
+## [Niewydane]
 
 ### Zmienione
 
@@ -27,7 +27,7 @@ a nie dacie commita podnoszącego numer wersji — te potrafiły różnić się 
   nieaktualny i wymagał ręcznego `clean`. Wspólny stempel projektu powoduje też, że zmiana
   `business.xml` regeneruje również `config.cs`. ([#99])
 
-## [1.2.0] – 2026-07-01
+## [1.2.0] - 2026-07-01
 
 > **Wymagana od enova365 2606.0.0 (NET 10).** Zmiana zależności i platformy testowej na zgodne
 > z .NET 10.
@@ -54,7 +54,7 @@ a nie dacie commita podnoszącego numer wersji — te potrafiły różnić się 
 
 - Referencja do `System.ValueTuple` oraz parametr `SonetaValueTuplePackageVersion` — zbędne na .NET 10.
 
-## [1.1.8] – 2026-06-05
+## [1.1.8] - 2026-06-05
 
 ### Zmienione
 
@@ -63,7 +63,7 @@ a nie dacie commita podnoszącego numer wersji — te potrafiły różnić się 
 - `README.md` dołączany do paczki jako opis pakietu na nuget.org (`PackageReadmeFile`).
 - Pula agentów builda w Azure Pipelines ustawiona na `windows-2022`.
 
-## [1.1.7] – 2025-10-27
+## [1.1.7] - 2025-10-27
 
 > **Wymagana od enova365 2510.0.0** w przypadku korzystania z warstwy testów integracyjnych —
 > zmieniła się biblioteka do wykonywania asercji.
@@ -74,7 +74,7 @@ a nie dacie commita podnoszącego numer wersji — te potrafiły różnić się 
   Parametr `SonetaFluentAssertionsPackageVersion` zastąpiony przez
   `SonetaAwesomeAssertionsPackageVersion`.
 
-## [1.1.6] – 2025-06-20
+## [1.1.6] - 2025-06-20
 
 ### Dodane
 
@@ -86,7 +86,7 @@ a nie dacie commita podnoszącego numer wersji — te potrafiły różnić się 
   NUnit3TestAdapter `4.5.0` → `5.0.0`, Microsoft.NET.Test.Sdk `17.8.0` → `17.13.0`,
   NSubstitute `5.1.0` → `5.3.0`, FluentAssertions `6.12.0` → `7.2.0`.
 
-## [1.1.5] – 2024-01-02
+## [1.1.5] - 2024-01-02
 
 ### Dodane
 
@@ -102,7 +102,7 @@ a nie dacie commita podnoszącego numer wersji — te potrafiły różnić się 
 
 - Referencja do `Moq` wraz z parametrem wersji.
 
-## [1.1.4] – 2022-11-25
+## [1.1.4] - 2022-11-25
 
 > **Wymagana od enova365 2306.0.0-net (.NET 6).**
 
@@ -110,7 +110,7 @@ a nie dacie commita podnoszącego numer wersji — te potrafiły różnić się 
 
 - Podniesienie wersji `FluentAssertions`.
 
-## [1.1.3] – 2022-09-26
+## [1.1.3] - 2022-09-26
 
 ### Dodane
 
@@ -121,7 +121,7 @@ a nie dacie commita podnoszącego numer wersji — te potrafiły różnić się 
 
 - `CopyLocalLockFileAssemblies` ustawiane wyłącznie dla projektów dodatków.
 
-## [1.1.2] – 2022-06-22
+## [1.1.2] - 2022-06-22
 
 > Kompatybilna z poprzednimi wersjami bibliotek FrameworkSoneta; nadaje się do kompilacji
 > w `netstandard2.0` od wersji enova365 2204.3.6.
@@ -134,13 +134,13 @@ a nie dacie commita podnoszącego numer wersji — te potrafiły różnić się 
 
 - `CopyLocalLockFileAssemblies` ustawione na `true`.
 
-## [1.1.1] – 2021-12-09
+## [1.1.1] - 2021-12-09
 
 ### Naprawione
 
 - Poprawka błędu zgłoszonego w [#49] dotyczącego `Sdk.targets`. ([#52])
 
-## [1.1.0] – 2021-03-24
+## [1.1.0] - 2021-03-24
 
 > **Zmiana łamiąca kompatybilność.** Korzystanie z tej wersji wymaga **usunięcia** z plików
 > `modul.business.xml` i `modul.config.xml` wpisu `<import>generator</import>`, jeżeli występuje.
@@ -155,7 +155,7 @@ a nie dacie commita podnoszącego numer wersji — te potrafiły różnić się 
 - Ścieżka przekazywana przez `extPath` ujęta w cudzysłów. ([#45])
 - Aktualizacja `Nerdbank.GitVersioning` do `3.3.37`.
 
-## [1.0.4] – 2020-04-06
+## [1.0.4] - 2020-04-06
 
 ### Dodane
 
@@ -167,7 +167,11 @@ a nie dacie commita podnoszącego numer wersji — te potrafiły różnić się 
 
 - Sparametryzowanie wersji `NSubstitute` i `FluentAssertions`. ([#34])
 
-## [1.0.3] – 2019-10-28
+## [1.0.3] - 2019-10-28
+
+### Dodane
+
+- Dokument `RELEASING.md` opisujący proces wydania. ([#23])
 
 ### Zmienione
 
@@ -179,15 +183,12 @@ a nie dacie commita podnoszącego numer wersji — te potrafiły różnić się 
 
 - Uzupełnienie brakującego `Condition` przy elemencie `Import`. ([#30])
 
-### Dokumentacja
-
-- Dodanie `RELEASING.md` opisującego proces wydania. ([#23])
-
-## [1.0.2] – 2019-09-20
+## [1.0.2] - 2019-09-20
 
 ### Dodane
 
 - Obsługa **wielu plików `business.xml`** w jednym projekcie. ([#15])
+- Dokument `VERSIONING.md` z instrukcją wersjonowania podczas wydania.
 
 ### Naprawione
 
@@ -195,11 +196,7 @@ a nie dacie commita podnoszącego numer wersji — te potrafiły różnić się 
 - Generator nie tworzył plików `config.cs` na podstawie `config.xml`. ([#16])
 - Wygenerowane pliki `*.business.cs` nie wchodzą już w skład paczki NuGet. ([#12])
 
-### Dokumentacja
-
-- Instrukcja wersjonowania podczas wydania (`VERSIONING.md`).
-
-## [1.0.1] – 2019-06-26
+## [1.0.1] - 2019-06-26
 
 ### Naprawione
 
@@ -213,7 +210,7 @@ a nie dacie commita podnoszącego numer wersji — te potrafiły różnić się 
 - Zniesienie grupowania w repozytorium plików `*.business.xml` / `*.config.xml`
   z odpowiadającymi im `*.cs`.
 
-## [1.0.0] – 2019-05-21
+## [1.0.0] - 2019-05-21
 
 Pierwsze publiczne wydanie SDK.
 
@@ -256,7 +253,7 @@ Historia wersji do 1.2.0 włącznie została odtworzona po fakcie. Warto znać j
   je jednoznacznie odczytać z komunikatów commitów. Odwołania do wewnętrznych identyfikatorów
   Azure DevOps (np. `Task #146366`) zostały pominięte jako niedostępne publicznie.
 
-[Nieopublikowane]: https://github.com/soneta/Soneta.MsBuild.SDK/compare/master...develop
+[Niewydane]: https://github.com/soneta/Soneta.MsBuild.SDK/compare/master...develop
 [1.2.0]: https://www.nuget.org/packages/Soneta.Sdk/1.2.0
 [1.1.8]: https://www.nuget.org/packages/Soneta.Sdk/1.1.8
 [1.1.7]: https://www.nuget.org/packages/Soneta.Sdk/1.1.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,291 @@
+# Changelog
+
+Wszystkie istotne zmiany w projekcie **Soneta.MsBuild.SDK** są dokumentowane w tym pliku.
+
+Format oparty jest na [Keep a Changelog](https://keepachangelog.com/pl/1.1.0/),
+a projekt stosuje [wersjonowanie semantyczne](https://semver.org/lang/pl/).
+
+Daty wydań odpowiadają dacie publikacji paczki na [nuget.org](https://www.nuget.org/packages/Soneta.Sdk/),
+a nie dacie commita podnoszącego numer wersji — te potrafiły różnić się o tygodnie.
+
+> **Uwaga o kompletności.** Wpisy dla wersji 1.0.0–1.2.0 zostały odtworzone wstecz z historii
+> gita, historii `version.json` i not wersji, które wcześniej znajdowały się na początku
+> `README.md`. Zakres zmian przypisano na podstawie commitów leżących na gałęzi `master`
+> pomiędzy kolejnymi commitami wydaniowymi. Szczegóły metody i znane niepewności opisano
+> w sekcji [Uwagi do rekonstrukcji](#uwagi-do-rekonstrukcji) na końcu pliku.
+
+## [Nieopublikowane]
+
+### Zmienione
+
+- **Generator: wykrywanie zmian po sumie kontrolnej treści zamiast po czasie modyfikacji pliku.**
+  Wejścia generatora (własne `*.business.xml` / `*.config.xml` oraz `*.business.xml` modułów
+  nadrzędnych) są haszowane (SHA256), a wynik zapisywany do pliku-stempla w `obj`. Regeneracja
+  następuje po zmianie treści, a nie po zmianie znacznika czasu. Rozwiązuje to dwa problemy:
+  `git checkout` ustawiał czas modyfikacji na „teraz" i wymuszał zbędne przegenerowania, a zmiana
+  wyłącznie schematu nadrzędnego nie zmieniała własnego XML, przez co `.cs` pozostawał
+  nieaktualny i wymagał ręcznego `clean`. Wspólny stempel projektu powoduje też, że zmiana
+  `business.xml` regeneruje również `config.cs`. ([#99])
+
+## [1.2.0] – 2026-07-01
+
+> **Wymagana od enova365 2606.0.0 (NET 10).** Zmiana zależności i platformy testowej na zgodne
+> z .NET 10.
+
+### Dodane
+
+- Obsługa **Microsoft.Testing.Platform (MTP)** dla projektów testowych: pakiety
+  `Microsoft.Testing.Extensions.CrashDump`, `HangDump`, `Retry` i `TrxReport` wraz z parametrami
+  wersji (`SonetaMicrosoftTestingExtensions*PackageVersion`). Runner NUnit dla MTP włączany
+  właściwością `EnableNUnitRunner` (domyślnie `true` dla projektów testowych).
+- Właściwość `SonetaPackageReferenceNeedsVersion`, przygotowana pod centralne zarządzanie
+  wersjami pakietów (`ManagePackageVersionsCentrally`).
+- Parametr `SonetaNSubstituteAnalyzersCSharpPackageVersion`.
+
+### Zmienione
+
+- Referencje do pakietów przebudowane z listy sztywnych wpisów `PackageReference` na **macierz
+  pozycji `SonetaPackage`** opisującą, który pakiet trafia do jakiego typu projektu
+  (testowy/dodatek). Ułatwia to nadpisywanie i rozszerzanie zestawu zależności.
+- Podniesione wersje narzędzi testowych: NUnit `4.3.2` → `4.4.0`, NUnit3TestAdapter `5.0.0` → `6.1.0`,
+  Microsoft.NET.Test.Sdk `17.13.0` → `18.0.1`, AwesomeAssertions `9.1.0` → `9.3.0`.
+
+### Usunięte
+
+- Referencja do `System.ValueTuple` oraz parametr `SonetaValueTuplePackageVersion` — zbędne na .NET 10.
+
+## [1.1.8] – 2026-06-05
+
+### Zmienione
+
+- Dostosowanie SDK do **.NET 10**.
+- Docelowe platformy samej paczki SDK: `netstandard1.4` → `netstandard2.0`.
+- `README.md` dołączany do paczki jako opis pakietu na nuget.org (`PackageReadmeFile`).
+- Pula agentów builda w Azure Pipelines ustawiona na `windows-2022`.
+
+## [1.1.7] – 2025-10-27
+
+> **Wymagana od enova365 2510.0.0** w przypadku korzystania z warstwy testów integracyjnych —
+> zmieniła się biblioteka do wykonywania asercji.
+
+### Zmienione
+
+- **Zmiana biblioteki asercji: `FluentAssertions` → `AwesomeAssertions`** (wersja `9.1.0`).
+  Parametr `SonetaFluentAssertionsPackageVersion` zastąpiony przez
+  `SonetaAwesomeAssertionsPackageVersion`.
+
+## [1.1.6] – 2025-06-20
+
+### Dodane
+
+- Rozpoznawanie plików `*.form.console.xml` oraz `*.form.browsernew.xml` jako `EmbeddedResource`.
+
+### Zmienione
+
+- Aktualizacja zależności narzędzi testowych: NUnit `3.14.0` → `4.3.2`,
+  NUnit3TestAdapter `4.5.0` → `5.0.0`, Microsoft.NET.Test.Sdk `17.8.0` → `17.13.0`,
+  NSubstitute `5.1.0` → `5.3.0`, FluentAssertions `6.12.0` → `7.2.0`.
+
+## [1.1.5] – 2024-01-02
+
+### Dodane
+
+- Obsługa wzorców **DOTX** (`*.dotx`) jako zasobów osadzonych.
+- Pliki `*.repx` (wydruki DevExpress) traktowane jako `EmbeddedResource`.
+
+### Zmienione
+
+- Dostosowanie przekazywania `extPath` do nowej składni z separatorem `--`; usunięcie cudzysłowów.
+- Podniesienie wersji narzędzi zewnętrznych: NUnit `3.14.0`, NUnit3TestAdapter `4.5`.
+
+### Usunięte
+
+- Referencja do `Moq` wraz z parametrem wersji.
+
+## [1.1.4] – 2022-11-25
+
+> **Wymagana od enova365 2306.0.0-net (.NET 6).**
+
+### Zmienione
+
+- Podniesienie wersji `FluentAssertions`.
+
+## [1.1.3] – 2022-09-26
+
+### Dodane
+
+- **Integracja `Soneta.Generator` jako zadania MSBuild** zamiast wywołania zewnętrznego procesu.
+- Narzędzia testowe dla projektów pod **.NET 6**.
+
+### Zmienione
+
+- `CopyLocalLockFileAssemblies` ustawiane wyłącznie dla projektów dodatków.
+
+## [1.1.2] – 2022-06-22
+
+> Kompatybilna z poprzednimi wersjami bibliotek FrameworkSoneta; nadaje się do kompilacji
+> w `netstandard2.0` od wersji enova365 2204.3.6.
+
+### Naprawione
+
+- Wyeliminowanie problemu **zduplikowanych referencji do `*.business.xml`**.
+
+### Zmienione
+
+- `CopyLocalLockFileAssemblies` ustawione na `true`.
+
+## [1.1.1] – 2021-12-09
+
+### Naprawione
+
+- Poprawka błędu zgłoszonego w [#49] dotyczącego `Sdk.targets`. ([#52])
+
+## [1.1.0] – 2021-03-24
+
+> **Zmiana łamiąca kompatybilność.** Korzystanie z tej wersji wymaga **usunięcia** z plików
+> `modul.business.xml` i `modul.config.xml` wpisu `<import>generator</import>`, jeżeli występuje.
+> Pozostawienie go powoduje konflikt dwóch sposobów pobierania generatora — nowego,
+> automatycznego z SDK, oraz starego, opartego na kopiowaniu generatora do folderu projektu —
+> czego skutkiem są **puste pliki `.cs`** wyprodukowane przez generator.
+
+### Zmienione
+
+- **Automatyczne pobieranie generatora przez SDK** w miejsce ręcznego kopiowania do projektu.
+- Ujednolicenie działania `Soneta.Generator` — obsługa `import` w trybie `--schema`. ([#43])
+- Ścieżka przekazywana przez `extPath` ujęta w cudzysłów. ([#45])
+- Aktualizacja `Nerdbank.GitVersioning` do `3.3.37`.
+
+## [1.0.4] – 2020-04-06
+
+### Dodane
+
+- Obsługa plików `form.xml` w wariantach **premium** i **standard**. ([#36])
+- Pliki XML związane z prawami oznaczane jako `EmbeddedResource`. ([#39])
+- Ostrzeżenie informujące o korzystaniu z nieaktualnej wersji SDK. ([#35])
+
+### Zmienione
+
+- Sparametryzowanie wersji `NSubstitute` i `FluentAssertions`. ([#34])
+
+## [1.0.3] – 2019-10-28
+
+### Zmienione
+
+- Uniezależnienie uruchamiania `SonetaAddonStartProgram` od właściwości `Configuration`. ([#31])
+- Uniezależnienie działania `AggregateOutput` od `StartProgram`, `SonetaAddonStartProgram`
+  i `Configuration`. ([#24])
+
+### Naprawione
+
+- Uzupełnienie brakującego `Condition` przy elemencie `Import`. ([#30])
+
+### Dokumentacja
+
+- Dodanie `RELEASING.md` opisującego proces wydania. ([#23])
+
+## [1.0.2] – 2019-09-20
+
+### Dodane
+
+- Obsługa **wielu plików `business.xml`** w jednym projekcie. ([#15])
+
+### Naprawione
+
+- Niewrażliwość na wielkość liter w nazwach `[Cc]onfig.xml` i `[Bb]usiness.xml`. ([#18])
+- Generator nie tworzył plików `config.cs` na podstawie `config.xml`. ([#16])
+- Wygenerowane pliki `*.business.cs` nie wchodzą już w skład paczki NuGet. ([#12])
+
+### Dokumentacja
+
+- Instrukcja wersjonowania podczas wydania (`VERSIONING.md`).
+
+## [1.0.1] – 2019-06-26
+
+### Naprawione
+
+- Uwzględnienie spacji w ścieżkach do plików `business.xml` projektu.
+- `SonetaGeneratorExe`, `SavedFile` oraz elementy `SonetaSchemaReference` ujęte w cudzysłowy.
+- Tymczasowa poprawka dla Visual Studio 2019: wywołanie `Compile` nie kompiluje ponownie
+  całego rozwiązania.
+
+### Zmienione
+
+- Zniesienie grupowania w repozytorium plików `*.business.xml` / `*.config.xml`
+  z odpowiadającymi im `*.cs`.
+
+## [1.0.0] – 2019-05-21
+
+Pierwsze publiczne wydanie SDK.
+
+### Dodane
+
+- Pliki konfiguracyjne SDK: `Sdk.props`, `Sdk.targets`, `common.items.props`.
+- Automatyczne referencje do pakietów `Soneta.Products.Modules` i `Soneta.Products.Test`
+  zależnie od typu projektu.
+- Automatyczne uruchamianie generatora (`ExecuteSonetaGenerator`) podczas budowania dodatku,
+  wraz z obsługą zapisu pojedynczego pliku.
+- Ekspozycja `business.xml` w paczkach NuGet.
+- Domyślne ustawienie `StartProgram` na `SonetaExplorer` oraz `StartArguments`
+  na `/extpath=<OutputPath>` dla projektów dodatków.
+- Referencja do `NUnitTestAdapter` dla projektów testowych oraz parametr
+  `SonetaNUnitPackageVersion`.
+- Flaga `UsingSonetaSdk` pozwalająca wyłączyć SDK dla wybranego projektu.
+- Licencja MIT.
+
+## Uwagi do rekonstrukcji
+
+Historia wersji do 1.2.0 włącznie została odtworzona po fakcie. Warto znać jej ograniczenia:
+
+- **Metoda.** Commit wydaniowy = commit ustawiający w `src/Soneta.Sdk/version.json` numer wersji
+  bez części *prerelease*. Zakres zmian danej wersji = commity na `master` pomiędzy poprzednim
+  a bieżącym commitem wydaniowym. Tam, gdzie kolejność commitów rozmijała się z ich datami
+  (skutek merge'y i cherry-picków), rozstrzygała pozycja w historii `master`, a nie data.
+- **Wersja 1.0.5 nie została nigdy opublikowana.** Numer został przygotowany w repozytorium
+  (commit `5bf25ae`, 2021-03-24), ale paczka nie trafiła na nuget.org — wydano od razu 1.1.0
+  tego samego dnia. W changelogu nie ma dla niej wpisu.
+- **Wersja 1.1.5 była wydawana dwukrotnie.** Pierwsze podejście z 2022-11-25 (`1db02fa`) zostało
+  wycofane commitem „Porządki w wydaniu wersji 1.1.4" (`bcfc11c`) i numer wrócił do 1.1.4.
+  Faktyczna publikacja 1.1.5 nastąpiła dopiero 2024-01-02.
+- **Przypisanie zmian w narzędziach testowych do 1.1.5 jest przybliżone.** Commity podnoszące
+  NUnit, test adapter i usuwające Moq powstały po commicie wydaniowym 1.1.5, ale przed datą
+  publikacji paczki — przypisano je do 1.1.5.
+- **Brakujące tagi.** Repozytorium zawiera tagi wyłącznie dla wersji 1.0.2, 1.0.3, 1.0.4, 1.1.0
+  i 1.1.1. Pozostałe dziesięć wydań nie ma tagów, ponieważ dotychczasowy proces przewidywał
+  tagowanie jako ostatni, ręczny krok po publikacji.
+- **Numery `#NN`** odnoszą się do zgłoszeń i Pull Requestów w tym repozytorium, o ile dało się
+  je jednoznacznie odczytać z komunikatów commitów. Odwołania do wewnętrznych identyfikatorów
+  Azure DevOps (np. `Task #146366`) zostały pominięte jako niedostępne publicznie.
+
+[Nieopublikowane]: https://github.com/soneta/Soneta.MsBuild.SDK/compare/master...develop
+[1.2.0]: https://www.nuget.org/packages/Soneta.Sdk/1.2.0
+[1.1.8]: https://www.nuget.org/packages/Soneta.Sdk/1.1.8
+[1.1.7]: https://www.nuget.org/packages/Soneta.Sdk/1.1.7
+[1.1.6]: https://www.nuget.org/packages/Soneta.Sdk/1.1.6
+[1.1.5]: https://www.nuget.org/packages/Soneta.Sdk/1.1.5
+[1.1.4]: https://www.nuget.org/packages/Soneta.Sdk/1.1.4
+[1.1.3]: https://www.nuget.org/packages/Soneta.Sdk/1.1.3
+[1.1.2]: https://www.nuget.org/packages/Soneta.Sdk/1.1.2
+[1.1.1]: https://www.nuget.org/packages/Soneta.Sdk/1.1.1
+[1.1.0]: https://www.nuget.org/packages/Soneta.Sdk/1.1.0
+[1.0.4]: https://www.nuget.org/packages/Soneta.Sdk/1.0.4
+[1.0.3]: https://www.nuget.org/packages/Soneta.Sdk/1.0.3
+[1.0.2]: https://www.nuget.org/packages/Soneta.Sdk/1.0.2
+[1.0.1]: https://www.nuget.org/packages/Soneta.Sdk/1.0.1
+[1.0.0]: https://www.nuget.org/packages/Soneta.Sdk/1.0.0
+[#12]: https://github.com/soneta/Soneta.MsBuild.SDK/pull/12
+[#15]: https://github.com/soneta/Soneta.MsBuild.SDK/pull/15
+[#16]: https://github.com/soneta/Soneta.MsBuild.SDK/pull/16
+[#18]: https://github.com/soneta/Soneta.MsBuild.SDK/pull/18
+[#23]: https://github.com/soneta/Soneta.MsBuild.SDK/pull/23
+[#24]: https://github.com/soneta/Soneta.MsBuild.SDK/pull/24
+[#30]: https://github.com/soneta/Soneta.MsBuild.SDK/pull/30
+[#31]: https://github.com/soneta/Soneta.MsBuild.SDK/pull/31
+[#34]: https://github.com/soneta/Soneta.MsBuild.SDK/pull/34
+[#35]: https://github.com/soneta/Soneta.MsBuild.SDK/pull/35
+[#36]: https://github.com/soneta/Soneta.MsBuild.SDK/pull/36
+[#39]: https://github.com/soneta/Soneta.MsBuild.SDK/pull/39
+[#43]: https://github.com/soneta/Soneta.MsBuild.SDK/pull/43
+[#45]: https://github.com/soneta/Soneta.MsBuild.SDK/pull/45
+[#49]: https://github.com/soneta/Soneta.MsBuild.SDK/issues/49
+[#52]: https://github.com/soneta/Soneta.MsBuild.SDK/pull/52
+[#99]: https://github.com/soneta/Soneta.MsBuild.SDK/pull/99

--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@
 [![Build Status](https://soneta.visualstudio.com/GitHub/_apis/build/status/Soneta.MsBuild.SDK?branchName=master)](https://soneta.visualstudio.com/GitHub/_build/latest?definitionId=2&branchName=master)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-MSBuild SDK do budowania dodatków dla **enova365**. Zdejmuje z projektu dodatku ręczną
-konfigurację: sam dobiera referencje do bibliotek Soneta, sam uruchamia generator kodu
-i sam rozpoznaje pliki zasobów charakterystyczne dla platformy.
+MSBuild SDK do budowania dodatków dla enova365 — automatyczne referencje, generator kodu i zasoby platformy.
+
+Zdejmuje z projektu dodatku ręczną konfigurację: sam dobiera referencje do bibliotek Soneta,
+sam uruchamia generator kodu i sam rozpoznaje pliki zasobów charakterystyczne dla platformy.
 
 > 📖 **Historia zmian:** [CHANGELOG.md](CHANGELOG.md) · **Proces wydania:** [RELEASING.md](RELEASING.md)
 

--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ mogą nadal współdziałać mimo różnicy wersji, ale przy większych zmianach
 Zmiany zgłaszamy przez Pull Request do gałęzi `develop`. Po decyzji o wydaniu `develop`
 jest scalany do `master`, co uruchamia publikację nowej wersji.
 
-Każdy PR zmieniający zachowanie SDK powinien dopisać wpis do sekcji **Nieopublikowane**
+Każdy PR zmieniający zachowanie SDK powinien dopisać wpis do sekcji **Niewydane**
 w [CHANGELOG.md](CHANGELOG.md).
 
 ### Testowanie zmian lokalnie

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ SDK dostarcza trzy pliki, które MSBuild wciąga do projektu dodatku automatyczn
 |---|---|
 | `Sdk.props` | Referencje do pakietów NuGet dobierane pod typ projektu (dodatek / UI / testy) oraz wartości domyślne parametrów. |
 | `Sdk.targets` | Przebieg budowania — przede wszystkim uruchomienie generatora zamieniającego pliki `*.business.xml` i `*.config.xml` na kod `*.cs`. Wersja generatora dobierana jest automatycznie do wersji bibliotek. |
-| `common.items.props` | Rozpoznawanie plików specyficznych dla platformy (`*.form.xml`, `*.dbinit.xml`, `*.repx` i inne) i oznaczanie ich jako `EmbeddedResource`. |
+| `common.items.props` | Rozpoznawanie plików specyficznych dla platformy (`*.*form.xml`, `*.dbinit.xml`, `*.repx` i inne) i oznaczanie ich jako `EmbeddedResource`. |
 
 W praktyce znika pytanie „którą wersję generatora podpiąć" — wynika ona z wersji bibliotek
 zadeklarowanej w jednym miejscu.
@@ -41,7 +41,7 @@ Wersję SDK dobiera się do wersji enova365, z którą budowany jest dodatek.
 
 | Wersja SDK | Wymagana od enova365 | Platforma | Uwagi |
 |---|---|---|---|
-| **1.2.0** | 2606.0.0 | .NET 10 | Przejście na Microsoft.Testing.Platform. Wsparcie Central Package Management. |
+| **1.2.0** | 2606.0.0 | .NET 10 | Przejście na Microsoft.Testing.Platform. |
 | 1.1.8 | — | .NET 10 | Pierwsze dostosowanie do .NET 10. |
 | 1.1.7 | 2510.0.0 | .NET 6+ | Wymagana przy korzystaniu z testów integracyjnych — zmiana biblioteki asercji na `AwesomeAssertions`. |
 | 1.1.6 | — | .NET 6+ | Aktualizacja zależności testowych (NUnit 4). |

--- a/README.md
+++ b/README.md
@@ -1,111 +1,312 @@
-### Wersja SDK 1.2.0 jest wymagana od wersji enova365 2606.0.0 (NET10). Zmiana zależności i platformy testowej na zgodne z NET10.
-
-### Wersja SDK 1.1.7 jest wymagana od wersji enova365 2510.0.0 w przypadku wykorzystania warstwy testów integracyjnych. Nastąpiła zmiana wykorzystywanej bliblioteki do wykonywania assercji.
-
-### Wersja SDK 1.1.6 - aktualizacja zależności
-
-### Wersja SDK 1.1.5 - dodatnie obsługi wzorców DOCX
-
-### Wersja SDK 1.1.4 jest wymagana od wersji enova365 2306.0.0-net (NET 6)
-
-### Wersja SDK 1.1.2 jest kompatybilna z poprzednimi wersjami bibliotek FrameworkSoneta, a także do wykorzystania do kompilacji w netstandard2.0 od wersji enova365 2204.3.6
-
-### Wersja SDK 1.1.0 jest do wykorzystania od wersji enova365 2106.0.0
-**!!! Korzystanie z tej wersji SDK wymaga usunięcia z plików modul.business.xml i modul.config.xml wpisu (jeżeli występuje):**
-
-`<import>generator<import>`
-
-Pozostawienie wpisu spowoduje konflikt dwóch sposobów pobierania generatora - nowego, automatycznego z SDK oraz starego - kopiowania generatora do folderu projektu, co zaskutkuje wygenerowaniem pustych plików.cs przez generator.
-
 # Soneta.MsBuild.SDK
 
 [![NuGet](https://img.shields.io/nuget/v/Soneta.Sdk.svg)](https://www.nuget.org/packages/Soneta.Sdk)
-  [![NuGet](https://img.shields.io/nuget/dt/Soneta.Sdk.svg)](https://www.nuget.org/packages/Soneta.Sdk)
-  [![Build Status](https://soneta.visualstudio.com/GitHub/_apis/build/status/Soneta.MsBuild.SDK?branchName=master)](https://soneta.visualstudio.com/GitHub/_build/latest?definitionId=2&branchName=master)
-  
-# Wstęp 
-SDK (Software Development Kit) jest to zestaw narzędzi dla programistów niezbędnych w tworzeniu aplikacji z danej biblioteki. Soneta.MsBuild.SDK jest zestawem narzędzi niezbędnym do tworzenie dodatków dla sytemu enova365. Pozwala automatycznie skonfigurować projekt oraz uzupełniać projekty dodatku o niezbędne elementy potrzebne do wsprółpracy z oprogramowaniem enova365. Do elementów konfiguracyjnych Soneta SDK zaliczamy następujące pliki wraz z ich przeznaczeniem:<br>
-<ul>
-  <li><b>Common.item.props</b> -plik zapewnia automatyczną obsługę dołączania nowych plików do projektu. Między innymi pliki *.pageform.xml, *dbinit.xml zostaną automatycznie skonfigurowane jako EmbeddResource.</li>
+[![NuGet](https://img.shields.io/nuget/dt/Soneta.Sdk.svg)](https://www.nuget.org/packages/Soneta.Sdk)
+[![Build Status](https://soneta.visualstudio.com/GitHub/_apis/build/status/Soneta.MsBuild.SDK?branchName=master)](https://soneta.visualstudio.com/GitHub/_build/latest?definitionId=2&branchName=master)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-  <li><b>Sdk.props</b> -plik zapewnia poprawne utworzenie referencji dla różnych typów projektów np. Dla projektu testowego zostaną załadowane biblioteki testowe.</li>
-  <li><b>Sdk.targets</b> -plik przechowuje informacje dotyczące procesu budowanie m.in. automatycznego uruchamiania generatora tworzenia definicji baz danych (*.business.cs). Podsumowując prostymi słowami, od teraz nie będzie trzeba się zastanawiać, którą wersję generatora powinniśmy podpiąć, ponieważ zostanie to wykonane automatycznie.</li>
-</ul>
+MSBuild SDK do budowania dodatków dla **enova365**. Zdejmuje z projektu dodatku ręczną
+konfigurację: sam dobiera referencje do bibliotek Soneta, sam uruchamia generator kodu
+i sam rozpoznaje pliki zasobów charakterystyczne dla platformy.
 
-# Pierwsze kroki
-## Zdefiniowanie wersji Soneta.sdk.<br>
+> 📖 **Historia zmian:** [CHANGELOG.md](CHANGELOG.md) · **Proces wydania:** [RELEASING.md](RELEASING.md)
 
-W celu zaimportowania **Soneta.MsBuild.SDK** do projektu dodatku w pliku "**nazwaprojektu.csproj**" edytujemy linię dotyczącą projektu: 
+## Spis treści
+
+- [Co robi SDK](#co-robi-sdk)
+- [Kompatybilność](#kompatybilność)
+- [Pierwsze kroki](#pierwsze-kroki)
+- [Typy projektów](#typy-projektów)
+- [Pliki rozpoznawane automatycznie](#pliki-rozpoznawane-automatycznie)
+- [Parametry konfiguracyjne](#parametry-konfiguracyjne)
+- [Studium przypadku: biblioteki spoza SonetaPackage](#studium-przypadku-biblioteki-spoza-sonetapackage)
+- [Współpraca](#współpraca)
+
+## Co robi SDK
+
+SDK dostarcza trzy pliki, które MSBuild wciąga do projektu dodatku automatycznie:
+
+| Plik | Odpowiada za |
+|---|---|
+| `Sdk.props` | Referencje do pakietów NuGet dobierane pod typ projektu (dodatek / UI / testy) oraz wartości domyślne parametrów. |
+| `Sdk.targets` | Przebieg budowania — przede wszystkim uruchomienie generatora zamieniającego pliki `*.business.xml` i `*.config.xml` na kod `*.cs`. Wersja generatora dobierana jest automatycznie do wersji bibliotek. |
+| `common.items.props` | Rozpoznawanie plików specyficznych dla platformy (`*.form.xml`, `*.dbinit.xml`, `*.repx` i inne) i oznaczanie ich jako `EmbeddedResource`. |
+
+W praktyce znika pytanie „którą wersję generatora podpiąć" — wynika ona z wersji bibliotek
+zadeklarowanej w jednym miejscu.
+
+## Kompatybilność
+
+Wersję SDK dobiera się do wersji enova365, z którą budowany jest dodatek.
+
+| Wersja SDK | Wymagana od enova365 | Platforma | Uwagi |
+|---|---|---|---|
+| **1.2.0** | 2606.0.0 | .NET 10 | Przejście na Microsoft.Testing.Platform. Wsparcie Central Package Management. |
+| 1.1.8 | — | .NET 10 | Pierwsze dostosowanie do .NET 10. |
+| 1.1.7 | 2510.0.0 | .NET 6+ | Wymagana przy korzystaniu z testów integracyjnych — zmiana biblioteki asercji na `AwesomeAssertions`. |
+| 1.1.6 | — | .NET 6+ | Aktualizacja zależności testowych (NUnit 4). |
+| 1.1.5 | — | .NET 6+ | Obsługa wzorców DOTX i wydruków `*.repx`. |
+| 1.1.4 | 2306.0.0-net | .NET 6 | |
+| 1.1.2 | 2204.3.6 | `netstandard2.0` | Zachowuje zgodność z wcześniejszymi wersjami bibliotek FrameworkSoneta. |
+| 1.1.0 | 2106.0.0 | .NET Framework | ⚠️ Zmiana łamiąca — patrz niżej. |
+
+> ⚠️ **Migracja na 1.1.0 i nowsze.** Z plików `modul.business.xml` i `modul.config.xml` należy
+> **usunąć** wpis `<import>generator</import>`, jeżeli występuje. Pozostawienie go powoduje
+> konflikt dwóch sposobów pobierania generatora — nowego, automatycznego z SDK, oraz starego,
+> opartego na kopiowaniu generatora do folderu projektu. Skutkiem są **puste pliki `.cs`**
+> wyprodukowane przez generator.
+
+Pełna lista zmian: [CHANGELOG.md](CHANGELOG.md).
+
+## Pierwsze kroki
+
+### 1. Wskazanie SDK w projekcie
+
+W pliku `.csproj` dodatku wskaż SDK zamiast domyślnego:
+
 ```xml
-   <Project Sdk="Soneta.Sdk/numerWersji">  
-```
-Po zapisie zmian zostanie wykonana automatyczna konfiguracja projektu.
-
-
-W przypadku gdy w solucji znajduje się wiele projektów, by uniknąć konieczności zmian w każdym projekcie numeru wersji, istnieje możliwość stworzenia pliku nadrzędnego **"global.json"** (poza projektami) o zawartości: 
-```json
-   { 
-     "msbuild-sdks": { 
-        "Soneta.Sdk": "numerWersji" 
-      }
-   } 
-```
- Dzięki czemu w plikach "**.csproj**" wymagany będzie tylko wpis bez konieczności umieszczania numeru wersji. **Najnowszą** opublikowaną **wersję** dodatku **Soneta.MsBuild.SDK** znajdziemy [tutaj](https://www.nuget.org/packages/Soneta.Sdk/)
- ## Zdefiniowanie wersji bibliotek 
- Powinniśmy także utworzyć plik **"Directory.Build.props"** o zawartości:
- ```json
- <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <SonetaPackageVersion>1905.0.1</SonetaPackageVersion>
-    <SonetaTargetFramework>net46</SonetaTargetFramework>
-  </PropertyGroup>
-</Project>
-```
-Plik „**Directory.Build.props**” zawiera informację o wersji bibliotek pobieranych przez Soneta.SDK. Dzięki temu nie musimy już manualnie dodawać referencji do bibliotek Sonety tylko globalnie definiujemy wersję bibliotek z której ma korzystać dodatek. Należy tutaj wspomnieć, że dzięki takiemu rozwiązaniu możemy łatwo zmienić wersję bibliotek, którą chcemy wykorzystać w naszym dodatku. Wersję bibliotek Sonety definiujemy za pomocą parametru "**SonetaPackageVersion**", który wskazuje na wersję paczki [Soneta.Product.Modules](https://www.nuget.org/packages/Soneta.Products.Modules/) . W pliku „Directory.Build.props” mamy także **możliwość zdefiniowania własnych zmiennych**, które mogą być później używane w naszych projektach.<br>
-Kolejnym ważnym elementem znajdującym się w pliku „Directory.Build.props jest wersja .NET, którą używamy w naszej solucji. Dzięki temu każdy plik "**.csproj**" może odwołać się do parametru **SonetaTargetFramework** zdefiniowanego w jednym miejscu. Poniżej przedstawiono zawartość pliku "***.csproj**" wykorzystujący **Soneta.MsBuild.SDK**.
-```json
-<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Soneta.Sdk">
+<Project Sdk="Soneta.Sdk/1.2.0">
   <PropertyGroup>
     <TargetFramework>$(SonetaTargetFramework)</TargetFramework>
   </PropertyGroup>
 </Project>
 ```
 
-# Informacje Ogólne
-Soneta.sdk obsługuje **3 typy projektów**, które można stworzyć. W zależności od rodzaju projektu pobierane są inne biblioteki. Możemy stworzyć takie projekty jak:<br>
-<ul>
-   <li>Projekt testowy, który w swojej nazwie będzie zawierał słowo "**Test**"</li>
-   <li>Projekt interfejsu użytkownika kończacy się na wyrażeniu "***.UI**"</li>
-   <li>Projekt dodatku zawierający elementy logiki biznesowej</li>
-</ul>
+Po zapisaniu pliku konfiguracja projektu wykona się automatycznie.
 
-Istnieje możliwość stworzenia **projektu testowego**, który nie podąża za wyżej opisaną konwencją. Można to zrobić poprzez ustawienie w pliku **.csproj** flagi **\<IsTestProject>true\</IsTestProject>**.<br>
-Możemy także wykorzystać takie parametry jak:<br>
-<ul>
-  <li><b>AggregateOutput</b> - przyjmuje true/false, domyślnie true. Ustawiony na true, sprawia, iż wszystkie projekty (z wyjątkiem projektu testów) budują się do zbiorczego folderu. Domyślnie będzie on znajdował się o poziom wyżej niż sam folder zawierający projekt: '..\bin' lub w innej lokalizacji jawnie przypisanej do parametru AggregatePath. Parametr ten gromadzi output niemal wszystkich projektów solucji we wspólnej lokalizacji nie tracąc przy tym struktury folderów dla domyślnie wyliczanego parametru OutputPath (np. ..\bin\debug\net46\). Jeśli parametr jest ustawiony na false, zostanie przywrócone domyślne zachowanie. Oznacza to, że folderem decelowym dla każdego projektu będzie ten folder, w którym znajduje się plik projektu.</li>
-  <li><b>AggregatePath</b> - domyślnie '..\' (folder nadrzędny względem bieżącego foldera). W przypadku, gdy parametr AggregateOutput ustawiony jest na true, jest to ścieżka względna lub bezwzględna, która zostanie dodana na początku automatycznie wyliczonego atrybutu OutputPath. W przypadku domyślnych ustawień ostateczna wartość OutputPath może przyjąć postać np. '..\bin\debug\net46\'. Jeśli OutputPath zostanie ustawione jawnie w projekcie lub pliku Directory.Build, AggregatePath zostanie zignorowane. W takim wypadku wszystkie pliki generowane przez projekt zostaną wrzucone bezpośrednio do lokalizacji jawnie wskazanej przez parametr OutputPath. Celem wprowadzenia parametru AggregateOutput i AggregatePath było umożliwienie budowania wielu projektów do wspólnej lokalizacji.</li>
-  <li><b>EnableDefaultSonetaPackageReferences</b> – przyjmuje true/false, domyślnie true. Jeżeli parametr będzie ustawiony na false to Soneta.MsBuild.SDK nie będzie automatycznie dołączać referencji do bibliotek biznesowych.</li>
-  <li><b>UsingSonetaSdk</b> - przyjmuje true/false, domyślnie true. Pozwala zdecydować czy dany projekt korzysta z Soneta.MsBuild.SDK.</li>
-  <li><b>SonetaValueTuplePackageVersion, SonetaNUnitPackageVersion, SonetaNUnitTestAdapterPackageVersion</b> - parametry opisujące wersję pakietów.</li>
-  <li><b>SonetaAddonStartProgram</b> - ścieżka do programu, wraz z którym powinien być uruchamiany dodatek. Domyślna wartość dla tego parametru jest wyliczana w oparciu o ścieżkę, w której domyślnie instalowane jest oprogramowanie firmy Soneta (<b>C:\Program Files (x86)\Soneta\</b>). Spośród wszystkich zainstalowanych w takiej lokalizacji wersji programu, wybierana jest ostatnia. Jeśli program, z którym powinien być uruchamiany dodatek znajduje się w innej lokalizacji, należy ścieżkę do niego przypisać do tego parametru (np: 
-<b>C:\Program Files (x86)\Soneta\enova365 2002.0.0.17856\SonetaExplorer.exe</b>). Działanie parametru <b>SonetaAddonStartProgram</b> opiera się na automatycznym ustawieniu programu startowego i przekazaniu mu argumentu (parametr uruchomieniowy): 
-<b>/extpath=<ścieżka do binariów projektu></b>. W celu wyłączenia tego mechanizmu wystarczy jawnie ustawić <b>SonetaAddonStartProgram</b> na pustą wartość. Mechanizm ten nie nadpisze jawnie ustawionego parametru <b>StartProgram</b>, ani ustawień zapisanych w pliku <b>launchSettings.json</b>, w którym także można jawnie wskazać program startowy. Jeśli mechanizm oparty o <b>SonetaAddonStartProgram</b> nie działa poprawnie, należy w pierwszej kolejności sprawdzić, czy nie jest on nadpisywany przez wyżej wymienione ustawienia.</li>
-</ul>
+### 2. Wersja SDK w jednym miejscu (zalecane)
 
+Przy wielu projektach w rozwiązaniu wygodniej jest podać wersję SDK raz — w pliku `global.json`
+położonym obok pliku rozwiązania:
 
-Wraz z bibliotekami jest pobierana odpowiednia wersja generatora. Zadaniem generatora jest przekonwertowanie plików „.xml” na pliki „.cs”. Konwersja wykonywana jest podczas budowania dodatku.   
-
-# Studium przypadku
-## Korzystanie z bibliotek Soneta, niedostarczanych automatycznie przez **Soneta.MsBuild.SDK** (na przykładzie dodatków opartych o biblioteki WinForms)
-
-W wielu przypadkach do utworzenia lub zaktualizowania dodatku w oparciu o Soneta Sdk, wszystkie niezbędne biblioteki Soneta zostaną dostarczone automatycznie.
-Czasem jednak istnieje potrzeba skorzystania z bibliotek nie ujętych w zakresie **SonetaPackage**. Przykładem może być aktualizacja dodatku, którego interfejs użytkownika został zbudowany przed wprowadzeniem mechanizmu form.xml, za pomocą bibliotek opartych o technologię WinForms. **W większości przypadków najlepszym rozwiązaniem takiego problemu jest zaktualizowanie dodatku do formatu form.xml, który jest w pełni wspierany i kompatybilny z Sdk**.
-
-Z przyczyn biznesowych lub technicznych takie rozwiązanie nie zawsze jest możliwe. Aby mimo wszystko umożliwić takim dodatkom korzystanie z **Soneta.MsBuild.SDK** można jawnie zareferować do brakujących bibliotek, np. znajdujących się w folderze instalacyjnym programu enova365. Z poziomu **Visual Studio** referencję można dodać bezpośrednio z interfejsu użytkownika. W tym celu w oknie eksploratora solucji należy kliknąć odpowiedni projekt dodatku prawym przyciskiem myszy. Następnie, w menu kontekstowym, wybrać Add/Reference i wskazać odpowiedni plik DLL. Referencję można także dodać bezpośrednio w pliku projektu \*.csproj, dopisując do niego poniższy fragment kodu. 
-
+```json
+{
+  "msbuild-sdks": {
+    "Soneta.Sdk": "1.2.0"
+  }
+}
 ```
+
+Wtedy w plikach `.csproj` wystarczy `<Project Sdk="Soneta.Sdk">`, bez numeru wersji.
+
+Najnowszą opublikowaną wersję znajdziesz na
+[nuget.org/packages/Soneta.Sdk](https://www.nuget.org/packages/Soneta.Sdk/).
+
+### 3. Wersja bibliotek Soneta
+
+Obok rozwiązania utwórz plik `Directory.Build.props`:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <PropertyGroup>
+    <SonetaPackageVersion>2606.0.0</SonetaPackageVersion>
+    <SonetaTargetFramework>net10.0</SonetaTargetFramework>
+  </PropertyGroup>
+</Project>
+```
+
+`SonetaPackageVersion` wskazuje wersję paczki
+[Soneta.Products.Modules](https://www.nuget.org/packages/Soneta.Products.Modules/), z której
+korzysta dodatek. Dzięki temu nie trzeba dodawać referencji ręcznie, a zmiana wersji bibliotek
+sprowadza się do zmiany jednej wartości.
+
+`SonetaTargetFramework` pozwala trzymać wersję .NET w jednym miejscu — każdy `.csproj` odwołuje
+się do niej zamiast powtarzać wartość.
+
+W `Directory.Build.props` można też definiować własne właściwości do użycia w projektach.
+
+## Typy projektów
+
+Zestaw referencji dobierany jest na podstawie **dwóch niezależnych flag**:
+
+| Flaga | Ustalana przez | Znaczenie |
+|---|---|---|
+| `IsTestProject` | nazwa projektu zawiera `Test`, albo wartość ustawiona jawnie | Projekt testowy. |
+| `IsAddonProject` | ustawiana automatycznie na `true`, gdy projekt deklaruje `<Project Sdk="Soneta.Sdk">` jako SDK zewnętrzne (`UsingMicrosoftNETSdk != true`) | Projekt dodatku budowany „pod" Soneta.Sdk. Gdy Soneta.Sdk jest importowane wewnątrz projektu korzystającego już z `Microsoft.NET.Sdk`, flaga pozostaje pusta. |
+
+Jeżeli projekt testowy nie trzyma się konwencji nazewniczej, ustaw flagę jawnie:
+
+```xml
+<PropertyGroup>
+  <IsTestProject>true</IsTestProject>
+</PropertyGroup>
+```
+
+Kombinacja obu flag decyduje o zestawie pakietów:
+
+| Pakiet | Test + dodatek | Test | Dodatek | Pozostałe |
+|---|:--:|:--:|:--:|:--:|
+| NUnit | ✅ | ✅ | — | — |
+| NUnit3TestAdapter | ✅ | ✅ | — | — |
+| Microsoft.NET.Test.Sdk | ✅ | ✅ | — | — |
+| Microsoft.Testing.Extensions.\* | ✅ | ✅ | — | — |
+| Soneta.Products.Test | ✅ | — | — | — |
+| NSubstitute | — | ✅ | — | — |
+| NSubstitute.Analyzers.CSharp | — | ✅ | — | — |
+| AwesomeAssertions | — | ✅ | — | — |
+| Soneta.Products.Modules | — | — | ✅ | — |
+
+Kolumny odpowiadają kombinacjom `IsTestProject` / `IsAddonProject`. Źródłem tej tabeli jest
+macierz `SonetaPackage` w `Sdk.props`.
+
+### Konwencja nazewnicza `.UI`
+
+Projekty warstwy interfejsu użytkownika nazywamy z sufiksem `.UI` — na przykład `Soneta.CRM.UI`
+obok biznesowego `Soneta.CRM`.
+
+Konwencja ta **nie wpływa na dobór referencji przez SDK** — z punktu widzenia budowania projekt
+`.UI` jest zwykłym projektem dodatku. Ma natomiast znaczenie **w czasie działania programu**,
+po stronie mechanizmów enova365:
+
+- **Rozwiązywanie typów w definicjach formularzy.** Gdy assembly nazywa się `X.UI`, platforma
+  odszukuje wśród jego referencji assembly `X` i dołącza je jako drugie źródło typów. Dzięki temu
+  formularze w `X.UI` odwołują się do typów z `X` bez pełnej kwalifikacji.
+- **Wydruki.** Szablony raportów szukane są w `X.Reports` na podstawie nazwy `X.UI`.
+- **Zasoby graficzne.** Ścieżki obrazów mapowane są między `X.Forms` a `X.UI`.
+
+Dlatego nazwę projektu UI warto ustalać zgodnie z konwencją, nawet jeśli SDK jej nie wymaga.
+
+## Pliki rozpoznawane automatycznie
+
+Poniższe pliki są bez dodatkowej konfiguracji oznaczane jako `EmbeddedResource`:
+
+| Kategoria | Wzorce |
+|---|---|
+| Formularze | `*.*form.xml` oraz warianty `*.*form.premium.xml`, `*.*form.standard.xml`, `*.*form.mobile.xml`, `*.*form.console.xml`, `*.*form.browsernew.xml` |
+| Konfiguracja i dane | `*.config.xml`, `*.dbinit.xml`, `*.publish.xml`, `*.convert.sql` |
+| Prawa i role | `*.role.xml`, `*.rightstree.xml` |
+| Wydruki | `*.repx`, `*.repx.cs`, `Repx\*.png`, `Repx\*.jpg`, `Repx\*.gif`, `Repx\*.bmp` |
+| Wzorce dokumentów | `*.dotx` |
+| Fragmenty kodu | `*.snippet.cs` |
+| Licencje | `Properties\licenses.licx*` |
+
+> **Uwaga na wzorzec `*.*form.xml`.** Gwiazdka przed `form` sprawia, że wzorzec obejmuje wszystkie
+> rodzaje formularzy — `*.pageform.xml`, `*.viewform.xml`, `*.lookupform.xml`, `*.gridform.xml`
+> i `*.form.xml`. Nie trzeba dopisywać ich osobno.
+
+Pliki traktowane inaczej niż jako zwykły zasób osadzony:
+
+| Wzorzec | Traktowanie |
+|---|---|
+| `*.business.xml` | **Nie** jest zasobem osadzonym. Trafia do paczki NuGet dodatku pod ścieżkę `schema\`, dzięki czemu moduły zależne widzą schemat. |
+| `*.business.cs`, `*.config.cs` | Kompilowane, oznaczone jako wygenerowane i podpięte w drzewie projektu pod odpowiadający im plik XML. |
+| `*.repx.cs`, `*.snippet.cs` | Jednocześnie kompilowane i osadzane jako zasób. |
+| `*.dll`, `*.exe`, `*.traineddata` | Kopiowane do katalogu wynikowego w trybie `PreserveNewest`. |
+
+Pliki `*.business.xml` i `*.config.xml` są wejściem dla generatora, który produkuje z nich
+odpowiadające im pliki `*.business.cs` i `*.config.cs`. Wygenerowany kod nie wchodzi w skład
+paczki NuGet dodatku.
+
+## Parametry konfiguracyjne
+
+### Sterowanie budowaniem
+
+| Parametr | Domyślnie | Opis |
+|---|---|---|
+| `EnableDefaultSonetaPackageReferences` | `true` | Gdy `false`, SDK nie dołącza automatycznie referencji do bibliotek biznesowych. |
+| `RunSonetaGenerator` | — (włączony) | Generator działa, dopóki parametr nie zostanie ustawiony na `false`. |
+| `IsTestProject` | wykrywane z nazwy projektu | Wymusza traktowanie projektu jako testowego. |
+| `UsingSonetaSdk` | `true` | Pozwala zdecydować, czy dany projekt korzysta z Soneta.MsBuild.SDK — patrz uwaga niżej. |
+
+> **Jak działa `UsingSonetaSdk`.** SDK ustawia tę flagę na `true` w momencie, gdy zostanie
+> załadowane. Korzystają z niej pliki `Directory.Build.props` po stronie rozwiązania, żeby nie
+> zaimportować SDK po raz drugi w projekcie, który deklaruje je już przez
+> `<Project Sdk="Soneta.Sdk">`. Typowy warunek wygląda tak:
+>
+> ```xml
+> <PropertyGroup>
+>   <ImportSonetaSdk Condition="'$(UsingSonetaSdk)' != 'true' AND '$(UsingMicrosoftNETSdk)' == 'true'">true</ImportSonetaSdk>
+> </PropertyGroup>
+> <Import Project="Sdk.props" Sdk="Soneta.Sdk" Condition="'$(ImportSonetaSdk)' == 'true'" />
+> ```
+>
+> Dzięki temu ustawienie `UsingSonetaSdk` na `true` w konkretnym projekcie wyłącza dla niego
+> automatyczny import SDK z `Directory.Build.props`.
+
+### Lokalizacja wyników budowania
+
+| Parametr | Domyślnie | Opis |
+|---|---|---|
+| `AggregateOutput` | `true` | Gdy `true`, wszystkie projekty poza testowymi budują się do wspólnego folderu zbiorczego, zachowując strukturę podfolderów (np. `..\bin\debug\net10.0\`). Gdy `false`, obowiązuje domyślne zachowanie MSBuild — każdy projekt buduje się do własnego folderu. |
+| `AggregatePath` | `..\` | Ścieżka (względna lub bezwzględna) doklejana na początku wyliczonego `OutputPath`. Ignorowana, jeżeli `OutputPath` ustawiono jawnie w projekcie lub w `Directory.Build.props`. |
+
+### Uruchamianie dodatku
+
+| Parametr | Domyślnie | Opis |
+|---|---|---|
+| `SonetaAddonStartProgram` | najnowsza wersja wykryta w `C:\Program Files (x86)\Soneta\` | Ścieżka do programu, z którym uruchamiany jest dodatek. |
+
+Mechanizm ustawia program startowy i przekazuje mu argument
+`/extpath=<ścieżka do binariów projektu>`. Aby go wyłączyć, ustaw parametr na pustą wartość.
+
+Mechanizm **nie nadpisze** jawnie ustawionego `StartProgram` ani ustawień z pliku
+`launchSettings.json`. Jeżeli nie działa zgodnie z oczekiwaniem, sprawdź w pierwszej kolejności
+te dwa miejsca.
+
+Przykład jawnego wskazania:
+
+```xml
+<PropertyGroup>
+  <SonetaAddonStartProgram>C:\Program Files (x86)\Soneta\enova365 2606.0.0.17856\SonetaExplorer.exe</SonetaAddonStartProgram>
+</PropertyGroup>
+```
+
+### Wersje pakietów zewnętrznych
+
+Każdy z parametrów nadpisuje wersję odpowiadającego mu pakietu NuGet. Wartości domyślne
+odpowiadają SDK 1.2.0.
+
+| Parametr | Domyślnie | Pakiet |
+|---|---|---|
+| `SonetaNUnitPackageVersion` | `4.4.0` | NUnit |
+| `SonetaNUnitTestAdapterPackageVersion` | `6.1.0` | NUnit3TestAdapter |
+| `SonetaMicrosoftNETTestSdkPackageVersion` | `18.0.1` | Microsoft.NET.Test.Sdk |
+| `SonetaNSubstitutePackageVersion` | `5.3.0` | NSubstitute |
+| `SonetaNSubstituteAnalyzersCSharpPackageVersion` | `1.0.17` | NSubstitute.Analyzers.CSharp |
+| `SonetaAwesomeAssertionsPackageVersion` | `9.3.0` | AwesomeAssertions |
+| `SonetaMicrosoftTestingExtensionsCrashDumpPackageVersion` | `2.0.2` | Microsoft.Testing.Extensions.CrashDump |
+| `SonetaMicrosoftTestingExtensionsHangDumpPackageVersion` | `2.0.2` | Microsoft.Testing.Extensions.HangDump |
+| `SonetaMicrosoftTestingExtensionsRetryPackageVersion` | `2.0.2` | Microsoft.Testing.Extensions.Retry |
+| `SonetaMicrosoftTestingExtensionsTrxReportPackageVersion` | `2.0.2` | Microsoft.Testing.Extensions.TrxReport |
+
+> Do wersji 1.1.6 włącznie biblioteką asercji było `FluentAssertions`, sterowane parametrem
+> `SonetaFluentAssertionsPackageVersion`. Od 1.1.7 zastąpiła je `AwesomeAssertions`.
+
+### Microsoft.Testing.Platform
+
+| Parametr | Domyślnie | Opis |
+|---|---|---|
+| `EnableNUnitRunner` | `true` dla projektów testowych | Włącza runner NUnit dla Microsoft.Testing.Platform. |
+
+
+### Powiadomienie o nieaktualnym SDK
+
+SDK potrafi sprawdzić, czy używana wersja jest aktualna, i ostrzec podczas budowania.
+
+| Parametr | Domyślnie | Opis |
+|---|---|---|
+| `SonetaSdkUpdateIntervalTime` | `None` | Jednostka odstępu między sprawdzeniami (`None` = sprawdzanie wyłączone). |
+| `SonetaSdkUpdateIntervalValue` | `1` | Liczba jednostek odstępu. |
+
+## Studium przypadku: biblioteki spoza SonetaPackage
+
+Zwykle wszystkie potrzebne biblioteki Soneta dostarcza SDK automatycznie. Czasem jednak
+dodatek potrzebuje biblioteki spoza zakresu **SonetaPackage** — typowo przy aktualizacji
+starszego dodatku, którego interfejs zbudowano na WinForms, przed wprowadzeniem mechanizmu
+`form.xml`.
+
+> **W większości przypadków najlepszym rozwiązaniem jest przeniesienie dodatku na format
+> `form.xml`**, który jest w pełni wspierany i zgodny z SDK.
+
+Gdy nie jest to możliwe, brakujące biblioteki można zareferować jawnie — na przykład z folderu
+instalacyjnego enova365.
+
+W Visual Studio: prawy przycisk myszy na projekcie → *Add* → *Reference* → wskazanie pliku DLL.
+
+Bezpośrednio w `.csproj`:
+
+```xml
 <ItemGroup>
   <Reference Include="Soneta.Forms">
     <HintPath>C:\Program Files (x86)\Soneta\enova365 1908.0.1.17324\Soneta.Forms.dll</HintPath>
@@ -115,27 +316,43 @@ Z przyczyn biznesowych lub technicznych takie rozwiązanie nie zawsze jest możl
 </ItemGroup>
 ```
 
-Jeśli istnieje potrzeba referowania do większej ilości bibliotek, można podać lokalizację, pod którą będą one wyszukiwane. W takim wypadku nie ma potrzeby dłużej korzystać z elementu HintPath. W tym celu w pliku projektu należy dodać poniższy fragment, gdzie w elemencie **ReferencePath** należy umieścić ścieżkę do folderu zawierającego biblioteki, do których odnosi się referencja.
+Przy większej liczbie bibliotek wygodniej wskazać folder wyszukiwania zamiast powtarzać
+`HintPath`:
 
-```
+```xml
 <PropertyGroup>
   <ReferencePath>C:\Program Files (x86)\Soneta\enova365 1908.0.1.17324\</ReferencePath>
   <AssemblySearchPaths>$(AssemblySearchPaths);$(ReferencePath);</AssemblySearchPaths>
 </PropertyGroup>
 ```
 
-Warto zwrócić uwagę, że jeśli zareferowane biblioteki, same w sobie referują do bibliotek Soneta dostarczanych przez Sdk, wersja bibliotek z obu źródeł powinna być zgodna. W przypadku podniesienia wersji **SonetaPackageVersion** w pliku **Directory.Build.props** pomimo różnicy wersji bibliotek DLL, nadal mogą one zachować zgodność. Może się jednak okazać, że w nowej paczce **SonetaPackage** zaszły znaczące zmiany uniemożliwiające dalsze współdziałanie bibliotek. W takim wypadku konieczne będzie zaktualizowanie referencji w dodatku do nowszej wersji bibliotek Soneta.
+⚠️ Jeżeli zareferowane biblioteki same odwołują się do bibliotek dostarczanych przez SDK,
+wersje z obu źródeł powinny być zgodne. Po podniesieniu `SonetaPackageVersion` biblioteki
+mogą nadal współdziałać mimo różnicy wersji, ale przy większych zmianach w paczce
+**SonetaPackage** konieczne będzie zaktualizowanie jawnych referencji.
 
-# Współpraca
-W celu zaproponowania zmian należy stworzyć Pull Request do gałęzi develop. Po podjęciu decyzji o wydaniu nowej wersji branch develop zostanie zmergowany do mastera i dodatek zostanie automatycznie wydany. 
-1. Po poprawnym zbudowaniu Sdk ustawiamy się w konsoli na ścieżce \bin\Release
-2. Wykonujemy push do naszego lokalnego folderu z paczkami: 
+## Współpraca
+
+Zmiany zgłaszamy przez Pull Request do gałęzi `develop`. Po decyzji o wydaniu `develop`
+jest scalany do `master`, co uruchamia publikację nowej wersji.
+
+Każdy PR zmieniający zachowanie SDK powinien dopisać wpis do sekcji **Nieopublikowane**
+w [CHANGELOG.md](CHANGELOG.md).
+
+### Testowanie zmian lokalnie
+
+Po zbudowaniu SDK opublikuj paczkę do lokalnego źródła, aby stała się widoczna dla nowo
+tworzonych projektów:
+
 ```powershell
-dotnet nuget push nazwaPaczki.nupkg -s C:\Users....nuget\packages
-``` 
-3. Dzięki powyższym czynnościom nasze SDK będzie widoczne dla naszych nowo utworzonych projektów. 
+cd bin\Release
+dotnet nuget push nazwaPaczki.nupkg -s C:\Users\<uzytkownik>\.nuget\packages
+```
 
-# Proces wydawania nowych wersji
-Dokument [instrukcja wydania] szczegółowo opisuje potrzebne czynności zmierzające do wydania nowej wersji.
+### Wydawanie nowych wersji
 
-[instrukcja wydania]: RELEASING.md
+Proces wydania opisuje [RELEASING.md](RELEASING.md).
+
+## Licencja
+
+[MIT](LICENSE)


### PR DESCRIPTION
Porządek w dokumentacji. Zmiany wyłącznie dokumentacyjne — zawartość paczki bez zmian, sprawdzone.

Closes #101
Dotyczy #77

### `CHANGELOG.md`

Historia wydań 1.0.0 – 1.2.0 w formacie [Keep a Changelog](https://keepachangelog.com/pl/1.1.0/), odtworzona z historii gita i `version.json`. Daty odpowiadają publikacjom na nuget.org, nie commitom podnoszącym wersję — te potrafiły różnić się o tygodnie. Sekcja *Uwagi do rekonstrukcji* opisuje przyjętą metodę i wskazuje miejsca niepewne, m.in. że wersja 1.0.5 nigdy nie została opublikowana, a 1.1.5 była wydawana dwukrotnie.

### `README.md`

Notki wersji zdjęte z góry pliku do CHANGELOG-a, HTML zamieniony na markdown, bloki z XML-em miały znacznik ` ```json `, poprawione literówki, zaktualizowane przykłady (było `1905.0.1` / `net46`).

Dodane: spis treści, macierz kompatybilności SDK ↔ enova365 ↔ platforma, tabela plików rozpoznawanych automatycznie, tabela parametrów z wartościami domyślnymi zweryfikowanymi względem `Sdk.props` i `Sdk.targets`.

Doprecyzowane względem kodu:

- wzorzec formularzy to `*.*form.xml` — obejmuje `pageform`, `viewform`, `lookupform` i `gridform`, nie tylko `form`;
- `*.business.xml` nie jest zasobem osadzonym, tylko trafia do paczki pod ścieżkę `schema\`;
- konwencja `.UI` nie wpływa na dobór referencji przez SDK, ma znaczenie po stronie platformy w czasie działania programu;
- `UsingSonetaSdk` ustawia SDK, a odczytują ją pliki `Directory.Build.props` rozwiązania, żeby nie zaimportować SDK po raz drugi.

### Poza zakresem

Osobne PR-y: wersje angielskie, `CONTRIBUTING.md`, przebudowa `RELEASING.md`, dotagowanie wydań wstecz.

